### PR TITLE
feat(previews): generate design preview thumbnails for 3 designs (#15)

### DIFF
--- a/public/designs/warm-saas.json
+++ b/public/designs/warm-saas.json
@@ -1,0 +1,213 @@
+{
+  "$schema": "https://sleek-ui.design/schema/design.v1.json",
+  "name": "warm-saas",
+  "version": "1.0.0",
+  "description": "Amber tones with a friendly, corporate aesthetic. Default light mode with warm, inviting colors perfect for SaaS applications.",
+  "categories": ["warm", "corporate"],
+  "author": {
+    "name": "sleek-ui",
+    "email": "hello@sleek-ui.design",
+    "url": "https://sleek-ui.design"
+  },
+  "tokens": {
+    "colors": {
+      "light": {
+        "background": "0 0% 100%",
+        "foreground": "30 10% 10%",
+        "muted": "30 20% 97%",
+        "muted-foreground": "30 8% 45%",
+        "primary": "38 92% 50%",
+        "primary-foreground": "0 0% 100%",
+        "secondary": "30 20% 96%",
+        "secondary-foreground": "30 10% 15%",
+        "accent": "38 92% 95%",
+        "accent-foreground": "38 92% 50%",
+        "destructive": "0 84.2% 60.2%",
+        "destructive-foreground": "0 0% 100%",
+        "border": "30 15% 88%",
+        "input": "30 15% 88%",
+        "ring": "38 92% 50%",
+        "card": "0 0% 100%",
+        "card-foreground": "30 10% 10%",
+        "success": "142 71% 45%",
+        "success-foreground": "0 0% 100%",
+        "warning": "38 92% 50%",
+        "warning-foreground": "0 0% 100%",
+        "info": "199 89% 48%",
+        "info-foreground": "0 0% 100%"
+      },
+      "dark": {
+        "background": "30 20% 8%",
+        "foreground": "30 15% 95%",
+        "muted": "30 20% 15%",
+        "muted-foreground": "30 10% 60%",
+        "primary": "38 92% 60%",
+        "primary-foreground": "0 0% 10%",
+        "secondary": "30 20% 15%",
+        "secondary-foreground": "30 15% 95%",
+        "accent": "38 92% 20%",
+        "accent-foreground": "38 92% 70%",
+        "destructive": "0 62.8% 30.6%",
+        "destructive-foreground": "0 0% 100%",
+        "border": "30 15% 25%",
+        "input": "30 15% 25%",
+        "ring": "38 92% 60%",
+        "card": "30 20% 12%",
+        "card-foreground": "30 15% 95%",
+        "success": "142 70% 50%",
+        "success-foreground": "0 0% 10%",
+        "warning": "38 92% 56%",
+        "warning-foreground": "0 0% 10%",
+        "info": "199 89% 55%",
+        "info-foreground": "0 0% 10%"
+      }
+    },
+    "typography": {
+      "fontFamily": {
+        "sans": "Plus Jakarta Sans",
+        "serif": "Plus Jakarta Sans",
+        "mono": "DM Mono"
+      },
+      "fontSize": {
+        "xs": "0.75rem",
+        "sm": "0.875rem",
+        "base": "1rem",
+        "lg": "1.125rem",
+        "xl": "1.25rem",
+        "2xl": "1.5rem",
+        "3xl": "1.875rem",
+        "4xl": "2.25rem"
+      },
+      "fontWeight": {
+        "normal": 400,
+        "medium": 500,
+        "semibold": 600,
+        "bold": 700
+      },
+      "lineHeight": {
+        "tight": "1.25",
+        "normal": "1.5",
+        "relaxed": "1.625"
+      },
+      "letterSpacing": {
+        "tight": "-0.025em",
+        "normal": "0",
+        "wide": "0.025em"
+      }
+    },
+    "spacing": {
+      "unit": "4px",
+      "xs": "4px",
+      "sm": "8px",
+      "md": "16px",
+      "lg": "24px",
+      "xl": "32px",
+      "2xl": "48px"
+    },
+    "radius": {
+      "sm": "0.125rem",
+      "default": "0.375rem",
+      "lg": "0.5rem",
+      "full": "9999px"
+    },
+    "shadows": {
+      "sm": "0 1px 2px 0 rgb(0 0 0 / 0.05)",
+      "default": "0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1)",
+      "lg": "0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)"
+    }
+  },
+  "fonts": {
+    "google": [
+      {
+        "family": "Plus Jakarta Sans",
+        "weights": [400, 500, 600, 700]
+      },
+      {
+        "family": "DM Mono",
+        "weights": [400, 500]
+      }
+    ],
+    "urls": [
+      {
+        "url": "https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap",
+        "format": "css2",
+        "family": "Plus Jakarta Sans"
+      },
+      {
+        "url": "https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&display=swap",
+        "format": "css2",
+        "family": "DM Mono"
+      }
+    ]
+  },
+  "accessibility": {
+    "contrastTarget": 4.5,
+    "focusRing": {
+      "width": "2px",
+      "color": "currentColor",
+      "offset": "2px"
+    },
+    "reducedMotion": true
+  },
+  "components": {
+    "button": {
+      "primary": {
+        "background": "primary",
+        "color": "primary-foreground",
+        "borderRadius": "radius.default",
+        "padding": "spacing.sm spacing.md",
+        "fontWeight": "semibold"
+      },
+      "secondary": {
+        "background": "secondary",
+        "color": "secondary-foreground",
+        "borderRadius": "radius.default",
+        "padding": "spacing.sm spacing.md",
+        "fontWeight": "medium"
+      },
+      "ghost": {
+        "background": "transparent",
+        "color": "foreground",
+        "borderRadius": "radius.default",
+        "padding": "spacing.sm spacing.md",
+        "fontWeight": "medium"
+      }
+    },
+    "card": {
+      "background": "card",
+      "color": "card-foreground",
+      "borderRadius": "radius.lg",
+      "padding": "spacing.lg",
+      "shadow": "shadows.default",
+      "border": "1px solid border"
+    },
+    "input": {
+      "background": "background",
+      "color": "foreground",
+      "borderRadius": "radius.default",
+      "padding": "spacing.sm spacing.md",
+      "border": "1px solid input",
+      "focusRing": "focusRing",
+      "placeholderColor": "muted-foreground"
+    }
+  },
+  "agentInstructions": {
+    "defaultMode": "light",
+    "steps": [
+      "Set CSS custom properties from tokens.colors on :root (light) and .dark (dark mode)",
+      "Set --radius from tokens.radius.default",
+      "Load fonts by adding the Google Fonts URL from fonts.urls as a <link> tag",
+      "Set font-family from tokens.typography.fontFamily",
+      "Apply component styles from the components field (Tailwind class names for shadcn projects)",
+      "Ensure focus states match accessibility.focusRing specification",
+      "Test both light and dark modes"
+    ]
+  },
+  "preview": {
+    "thumbnail": "/previews/warm-saas-thumb.svg",
+    "screenshots": {
+      "light": ["/previews/warm-saas-light.svg"],
+      "dark": ["/previews/warm-saas-dark.svg"]
+    }
+  }
+}

--- a/public/previews/neo-brutalist-dark.svg
+++ b/public/previews/neo-brutalist-dark.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="600" viewBox="0 0 800 600">
+  <rect width="800" height="600" fill="#0a0a0a"/>
+  <text x="400" y="40" text-anchor="middle" fill="#ffe066" font-family="Space Grotesk, sans-serif" font-size="28" font-weight="700">Neo-Brutalist — Dark Mode</text>
+  <rect x="50" y="70" width="200" height="80" fill="#1a1a1a" stroke="#ffe066" stroke-width="3"/>
+  <text x="150" y="115" text-anchor="middle" fill="#ffe066" font-family="Space Grotesk, sans-serif" font-size="14" font-weight="600">CARD</text>
+  <rect x="270" y="70" width="200" height="80" fill="#ffe066" stroke="#ffe066" stroke-width="3"/>
+  <text x="370" y="115" text-anchor="middle" fill="#000" font-family="Space Grotesk, sans-serif" font-size="14" font-weight="600">BUTTON</text>
+  <rect x="490" y="70" width="200" height="80" fill="#ff3333" stroke="#ffe066" stroke-width="3"/>
+  <text x="590" y="115" text-anchor="middle" fill="#fff" font-family="Space Grotesk, sans-serif" font-size="14" font-weight="600">ALERT</text>
+  <rect x="50" y="170" width="700" height="350" fill="#1a1a1a" stroke="#ffe066" stroke-width="3"/>
+  <rect x="80" y="200" width="150" height="30" fill="#ffe066" stroke="#ffe066" stroke-width="2"/>
+  <text x="155" y="220" text-anchor="middle" fill="#000" font-family="Space Grotesk, sans-serif" font-size="12" font-weight="600">PRIMARY</text>
+  <rect x="250" y="200" width="150" height="30" fill="#ffe066" stroke="#ffe066" stroke-width="2"/>
+  <text x="325" y="220" text-anchor="middle" fill="#000" font-family="Space Grotesk, sans-serif" font-size="12" font-weight="600">SECONDARY</text>
+  <rect x="420" y="200" width="150" height="30" fill="transparent" stroke="#ffe066" stroke-width="2"/>
+  <text x="495" y="220" text-anchor="middle" fill="#ffe066" font-family="Space Grotesk, sans-serif" font-size="12" font-weight="600">GHOST</text>
+  <rect x="80" y="260" width="300" height="40" fill="#fff" stroke="#ffe066" stroke-width="2"/>
+  <rect x="400" y="260" width="300" height="40" fill="#ffe066" stroke="#ffe066" stroke-width="2"/>
+  <rect x="80" y="320" width="620" height="40" fill="#1a1a1a" stroke="#ffe066" stroke-width="2"/>
+  <text x="390" y="345" text-anchor="middle" fill="#ffe066" font-family="Space Grotesk, sans-serif" font-size="14">Input field</text>
+  <rect x="80" y="380" width="150" height="40" fill="#ff3333" stroke="#ffe066" stroke-width="2"/>
+  <text x="155" y="405" text-anchor="middle" fill="#fff" font-family="Space Grotesk, sans-serif" font-size="14" font-weight="600">DANGER</text>
+  <rect x="250" y="380" width="150" height="40" fill="#00cc00" stroke="#ffe066" stroke-width="2"/>
+  <text x="325" y="405" text-anchor="middle" fill="#000" font-family="Space Grotesk, sans-serif" font-size="14" font-weight="600">SUCCESS</text>
+  <rect x="80" y="450" width="620" height="50" fill="#ffe066" stroke="#ffe066" stroke-width="3" stroke-dasharray="8 4"/>
+  <text x="390" y="482" text-anchor="middle" fill="#000" font-family="Space Grotesk, sans-serif" font-size="16" font-weight="700">BOX SHADOW BUTTON</text>
+  <text x="400" y="580" text-anchor="middle" fill="#999" font-family="Space Grotesk, sans-serif" font-size="14">Dark Mode Preview</text>
+</svg>

--- a/public/previews/neo-brutalist-light.svg
+++ b/public/previews/neo-brutalist-light.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="600" viewBox="0 0 800 600">
+  <rect width="800" height="600" fill="#f9f5f0"/>
+  <text x="400" y="40" text-anchor="middle" fill="#000" font-family="Space Grotesk, sans-serif" font-size="28" font-weight="700">Neo-Brutalist — Light Mode</text>
+  <rect x="50" y="70" width="200" height="80" fill="#fff" stroke="#000" stroke-width="3"/>
+  <text x="150" y="115" text-anchor="middle" fill="#000" font-family="Space Grotesk, sans-serif" font-size="14" font-weight="600">CARD</text>
+  <rect x="270" y="70" width="200" height="80" fill="#ffe066" stroke="#000" stroke-width="3"/>
+  <text x="370" y="115" text-anchor="middle" fill="#000" font-family="Space Grotesk, sans-serif" font-size="14" font-weight="600">BUTTON</text>
+  <rect x="490" y="70" width="200" height="80" fill="#ff3333" stroke="#000" stroke-width="3"/>
+  <text x="590" y="115" text-anchor="middle" fill="#fff" font-family="Space Grotesk, sans-serif" font-size="14" font-weight="600">ALERT</text>
+  <rect x="50" y="170" width="700" height="350" fill="#fff" stroke="#000" stroke-width="3"/>
+  <rect x="80" y="200" width="150" height="30" fill="#000" stroke="#000" stroke-width="2"/>
+  <text x="155" y="220" text-anchor="middle" fill="#fff" font-family="Space Grotesk, sans-serif" font-size="12" font-weight="600">PRIMARY</text>
+  <rect x="250" y="200" width="150" height="30" fill="#fff" stroke="#000" stroke-width="2"/>
+  <text x="325" y="220" text-anchor="middle" fill="#000" font-family="Space Grotesk, sans-serif" font-size="12" font-weight="600">SECONDARY</text>
+  <rect x="420" y="200" width="150" height="30" fill="transparent" stroke="#000" stroke-width="2"/>
+  <text x="495" y="220" text-anchor="middle" fill="#000" font-family="Space Grotesk, sans-serif" font-size="12" font-weight="600">GHOST</text>
+  <rect x="80" y="260" width="300" height="40" fill="#000" stroke="#000" stroke-width="2"/>
+  <rect x="400" y="260" width="300" height="40" fill="#ffe066" stroke="#000" stroke-width="2"/>
+  <rect x="80" y="320" width="620" height="40" fill="#fff" stroke="#000" stroke-width="2"/>
+  <text x="390" y="345" text-anchor="middle" fill="#666" font-family="Space Grotesk, sans-serif" font-size="14">Input field</text>
+  <rect x="80" y="380" width="150" height="40" fill="#ff3333" stroke="#000" stroke-width="2"/>
+  <text x="155" y="405" text-anchor="middle" fill="#fff" font-family="Space Grotesk, sans-serif" font-size="14" font-weight="600">DANGER</text>
+  <rect x="250" y="380" width="150" height="40" fill="#00cc00" stroke="#000" stroke-width="2"/>
+  <text x="325" y="405" text-anchor="middle" fill="#000" font-family="Space Grotesk, sans-serif" font-size="14" font-weight="600">SUCCESS</text>
+  <rect x="80" y="450" width="620" height="50" fill="#ffe066" stroke="#000" stroke-width="3" stroke-dasharray="8 4"/>
+  <text x="390" y="482" text-anchor="middle" fill="#000" font-family="Space Grotesk, sans-serif" font-size="16" font-weight="700">BOX SHADOW BUTTON</text>
+  <text x="400" y="580" text-anchor="middle" fill="#666" font-family="Space Grotesk, sans-serif" font-size="14">Light Mode Preview</text>
+</svg>

--- a/public/previews/neo-brutalist-thumb.svg
+++ b/public/previews/neo-brutalist-thumb.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="#f9f5f0"/>
+  <text x="200" y="50" text-anchor="middle" fill="#000" font-family="Space Grotesk, sans-serif" font-size="20" font-weight="700">Neo-Brutalist</text>
+  <rect x="40" y="70" width="100" height="60" fill="#ffe066" stroke="#000" stroke-width="3"/>
+  <rect x="160" y="70" width="100" height="60" fill="#000" stroke="#000" stroke-width="3"/>
+  <rect x="280" y="70" width="80" height="60" fill="#ff3333" stroke="#000" stroke-width="3"/>
+  <rect x="40" y="150" width="320" height="100" fill="#fff" stroke="#000" stroke-width="3"/>
+  <rect x="60" y="170" width="80" height="30" fill="#ffe066" stroke="#000" stroke-width="2"/>
+  <rect x="160" y="170" width="80" height="30" fill="#000" stroke="#000" stroke-width="2"/>
+  <rect x="260" y="170" width="80" height="30" fill="#ff3333" stroke="#000" stroke-width="2"/>
+  <text x="200" y="280" text-anchor="middle" fill="#666" font-family="Space Grotesk, sans-serif" font-size="12">Thumbnail</text>
+</svg>

--- a/public/previews/warm-saas-dark.svg
+++ b/public/previews/warm-saas-dark.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="600" viewBox="0 0 800 600">
+  <rect width="800" height="600" fill="#1a1412"/>
+  <text x="400" y="40" text-anchor="middle" fill="#f5f5f4" font-family="Plus Jakarta Sans, sans-serif" font-size="28" font-weight="600">Warm SaaS — Dark Mode</text>
+  <rect x="50" y="70" width="200" height="80" rx="8" fill="#292524" stroke="#44403c" stroke-width="1"/>
+  <text x="150" y="115" text-anchor="middle" fill="#f5f5f4" font-family="Plus Jakarta Sans, sans-serif" font-size="14" font-weight="500">CARD</text>
+  <rect x="270" y="70" width="200" height="80" rx="8" fill="#f97316"/>
+  <text x="370" y="115" text-anchor="middle" fill="#1a1412" font-family="Plus Jakarta Sans, sans-serif" font-size="14" font-weight="600">BUTTON</text>
+  <rect x="490" y="70" width="200" height="80" rx="8" fill="#22c55e"/>
+  <text x="590" y="115" text-anchor="middle" fill="#1a1412" font-family="Plus Jakarta Sans, sans-serif" font-size="14" font-weight="600">SUCCESS</text>
+  <rect x="50" y="170" width="700" height="350" rx="8" fill="#1c1917" stroke="#44403c" stroke-width="1"/>
+  <rect x="80" y="200" width="150" height="30" rx="6" fill="#f97316"/>
+  <text x="155" y="220" text-anchor="middle" fill="#1a1412" font-family="Plus Jakarta Sans, sans-serif" font-size="12" font-weight="600">PRIMARY</text>
+  <rect x="250" y="200" width="150" height="30" rx="6" fill="#292524" stroke="#44403c" stroke-width="1"/>
+  <text x="325" y="220" text-anchor="middle" fill="#d6d3d1" font-family="Plus Jakarta Sans, sans-serif" font-size="12" font-weight="500">SECONDARY</text>
+  <rect x="420" y="200" width="150" height="30" rx="6" fill="transparent"/>
+  <text x="495" y="220" text-anchor="middle" fill="#78716c" font-family="Plus Jakarta Sans, sans-serif" font-size="12" font-weight="500">GHOST</text>
+  <rect x="80" y="260" width="300" height="40" rx="6" fill="#292524" stroke="#44403c" stroke-width="1"/>
+  <text x="265" y="285" text-anchor="middle" fill="#78716c" font-family="Plus Jakarta Sans, sans-serif" font-size="14">Email</text>
+  <rect x="400" y="260" width="300" height="40" rx="6" fill="#f97316"/>
+  <text x="550" y="285" text-anchor="middle" fill="#1a1412" font-family="Plus Jakarta Sans, sans-serif" font-size="14" font-weight="600">Subscribe</text>
+  <rect x="80" y="320" width="620" height="40" rx="6" fill="#292524" stroke="#44403c" stroke-width="1"/>
+  <text x="390" y="345" text-anchor="middle" fill="#78716c" font-family="Plus Jakarta Sans, sans-serif" font-size="14">Password</text>
+  <rect x="80" y="380" width="150" height="40" rx="6" fill="#ef4444"/>
+  <text x="155" y="405" text-anchor="middle" fill="#fff" font-family="Plus Jakarta Sans, sans-serif" font-size="14" font-weight="500">Cancel</text>
+  <rect x="250" y="380" width="150" height="40" rx="6" fill="#22c55e"/>
+  <text x="325" y="405" text-anchor="middle" fill="#1a1412" font-family="Plus Jakarta Sans, sans-serif" font-size="14" font-weight="500">Save</text>
+  <rect x="80" y="440" width="150" height="40" rx="6" fill="#3b82f6"/>
+  <text x="155" y="465" text-anchor="middle" fill="#fff" font-family="Plus Jakarta Sans, sans-serif" font-size="14" font-weight="500">Info</text>
+  <rect x="250" y="440" width="150" height="40" rx="6" fill="#eab308"/>
+  <text x="325" y="465" text-anchor="middle" fill="#1a1412" font-family="Plus Jakarta Sans, sans-serif" font-size="14" font-weight="500">Warning</text>
+  <rect x="80" y="500" width="620" height="30" rx="4" fill="#292524"/>
+  <text x="390" y="520" text-anchor="middle" fill="#57534e" font-family="Plus Jakarta Sans, sans-serif" font-size="12">Footer text</text>
+  <text x="400" y="580" text-anchor="middle" fill="#78716c" font-family="Plus Jakarta Sans, sans-serif" font-size="14">Dark Mode Preview</text>
+</svg>

--- a/public/previews/warm-saas-light.svg
+++ b/public/previews/warm-saas-light.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="600" viewBox="0 0 800 600">
+  <rect width="800" height="600" fill="#fff"/>
+  <text x="400" y="40" text-anchor="middle" fill="#1a1412" font-family="Plus Jakarta Sans, sans-serif" font-size="28" font-weight="600">Warm SaaS — Light Mode</text>
+  <rect x="50" y="70" width="200" height="80" rx="8" fill="#fff7ed" stroke="#fed7aa" stroke-width="1"/>
+  <text x="150" y="115" text-anchor="middle" fill="#1a1412" font-family="Plus Jakarta Sans, sans-serif" font-size="14" font-weight="500">CARD</text>
+  <rect x="270" y="70" width="200" height="80" rx="8" fill="#f97316"/>
+  <text x="370" y="115" text-anchor="middle" fill="#fff" font-family="Plus Jakarta Sans, sans-serif" font-size="14" font-weight="600">BUTTON</text>
+  <rect x="490" y="70" width="200" height="80" rx="8" fill="#22c55e"/>
+  <text x="590" y="115" text-anchor="middle" fill="#fff" font-family="Plus Jakarta Sans, sans-serif" font-size="14" font-weight="600">SUCCESS</text>
+  <rect x="50" y="170" width="700" height="350" rx="8" fill="#fff" stroke="#fed7aa" stroke-width="1"/>
+  <rect x="80" y="200" width="150" height="30" rx="6" fill="#f97316"/>
+  <text x="155" y="220" text-anchor="middle" fill="#fff" font-family="Plus Jakarta Sans, sans-serif" font-size="12" font-weight="600">PRIMARY</text>
+  <rect x="250" y="200" width="150" height="30" rx="6" fill="#f3f4f6" stroke="#d1d5db" stroke-width="1"/>
+  <text x="325" y="220" text-anchor="middle" fill="#374151" font-family="Plus Jakarta Sans, sans-serif" font-size="12" font-weight="500">SECONDARY</text>
+  <rect x="420" y="200" width="150" height="30" rx="6" fill="transparent"/>
+  <text x="495" y="220" text-anchor="middle" fill="#6b7280" font-family="Plus Jakarta Sans, sans-serif" font-size="12" font-weight="500">GHOST</text>
+  <rect x="80" y="260" width="300" height="40" rx="6" fill="#fff" stroke="#fed7aa" stroke-width="1"/>
+  <text x="265" y="285" text-anchor="middle" fill="#9ca3af" font-family="Plus Jakarta Sans, sans-serif" font-size="14">Email</text>
+  <rect x="400" y="260" width="300" height="40" rx="6" fill="#f97316"/>
+  <text x="550" y="285" text-anchor="middle" fill="#fff" font-family="Plus Jakarta Sans, sans-serif" font-size="14" font-weight="600">Subscribe</text>
+  <rect x="80" y="320" width="620" height="40" rx="6" fill="#fff" stroke="#fed7aa" stroke-width="1"/>
+  <text x="390" y="345" text-anchor="middle" fill="#6b7280" font-family="Plus Jakarta Sans, sans-serif" font-size="14">Password</text>
+  <rect x="80" y="380" width="150" height="40" rx="6" fill="#ef4444"/>
+  <text x="155" y="405" text-anchor="middle" fill="#fff" font-family="Plus Jakarta Sans, sans-serif" font-size="14" font-weight="500">Cancel</text>
+  <rect x="250" y="380" width="150" height="40" rx="6" fill="#22c55e"/>
+  <text x="325" y="405" text-anchor="middle" fill="#fff" font-family="Plus Jakarta Sans, sans-serif" font-size="14" font-weight="500">Save</text>
+  <rect x="80" y="440" width="150" height="40" rx="6" fill="#3b82f6"/>
+  <text x="155" y="465" text-anchor="middle" fill="#fff" font-family="Plus Jakarta Sans, sans-serif" font-size="14" font-weight="500">Info</text>
+  <rect x="250" y="440" width="150" height="40" rx="6" fill="#eab308"/>
+  <text x="325" y="465" text-anchor="middle" fill="#1a1412" font-family="Plus Jakarta Sans, sans-serif" font-size="14" font-weight="500">Warning</text>
+  <rect x="80" y="500" width="620" height="30" rx="4" fill="#f3f4f6"/>
+  <text x="390" y="520" text-anchor="middle" fill="#9ca3af" font-family="Plus Jakarta Sans, sans-serif" font-size="12">Footer text</text>
+  <text x="400" y="580" text-anchor="middle" fill="#666" font-family="Plus Jakarta Sans, sans-serif" font-size="14">Light Mode Preview</text>
+</svg>

--- a/public/previews/warm-saas-thumb.svg
+++ b/public/previews/warm-saas-thumb.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="#fff"/>
+  <text x="200" y="50" text-anchor="middle" fill="#1a1412" font-family="Plus Jakarta Sans, sans-serif" font-size="20" font-weight="600">Warm SaaS</text>
+  <rect x="40" y="70" width="100" height="60" rx="8" fill="#ffedd5" stroke="#fed7aa" stroke-width="1"/>
+  <rect x="160" y="70" width="100" height="60" rx="8" fill="#f97316"/>
+  <rect x="280" y="70" width="80" height="60" rx="8" fill="#22c55e"/>
+  <rect x="40" y="150" width="320" height="100" rx="8" fill="#fff7ed" stroke="#fed7aa" stroke-width="1"/>
+  <rect x="60" y="170" width="80" height="30" rx="4" fill="#f97316"/>
+  <rect x="160" y="170" width="80" height="30" rx="4" fill="#22c55e"/>
+  <rect x="260" y="170" width="80" height="30" rx="4" fill="#3b82f6"/>
+  <text x="200" y="280" text-anchor="middle" fill="#666" font-family="Plus Jakarta Sans, sans-serif" font-size="12">Thumbnail</text>
+</svg>


### PR DESCRIPTION
Closes #15

## Summary

Added design preview thumbnails and screenshots for all 3 Phase 1 designs:
- neo-brutalist (thumb, light, dark)
- warm-saas (thumb, light, dark)  
- editorial-dark (already existed)

## Changes

| File | Change |
|------|--------|
| `public/designs/warm-saas.json` | Added warm-saas design file from feature branch |
| `public/previews/neo-brutalist-thumb.svg` | New thumbnail (400x300) |
| `public/previews/neo-brutalist-light.svg` | New light screenshot (800x600) |
| `public/previews/neo-brutalist-dark.svg` | New dark screenshot (800x600) |
| `public/previews/warm-saas-thumb.svg` | New thumbnail (400x300) |
| `public/previews/warm-saas-light.svg` | New light screenshot (800x600) |
| `public/previews/warm-saas-dark.svg` | New dark screenshot (800x600) |

## Acceptance Criteria

- [x] For each design: `public/previews/{slug}-thumb.svg`, `{slug}-light.svg`, `{slug}-dark.svg`
- [x] Thumbnails: 400×300px minimum, shows representative color palette
- [x] Screenshots: 800×600px minimum, shows design applied to representative UI
- [x] Images are web-optimized (< 200KB each) - all files under 4KB
- [x] Paths match the `preview` field values in each design JSON

## Test Results

- Design validation: 3/3 designs valid
- Build: passed
- Tests: none configured

## Notes

- warm-saas design was cherry-picked from feature/13-warm-saas-design branch
- The acceptance criteria specified .png files but existing design JSONs reference .svg files; SVG format is web-optimized and scalable