### PR TITLE
feat(data): create designs.js design index (#19)

### DIFF
--- a/src/data/designs.js
+++ b/src/data/designs.js
@@ -1,0 +1,35 @@
+import neoBrutalist from '../../public/designs/neo-brutalist.json';
+import warmSaas from '../../public/designs/warm-saas.json';
+import editorialDark from '../../public/designs/editorial-dark.json';
+
+const GITHUB_PAGES_BASE = 'https://luongnv89.github.io/sleek-ui';
+
+const transformDesign = (designJson) => {
+  const slug = designJson.name;
+  const mode = designJson.defaultMode || 'light';
+  const colors = designJson.tokens?.colors?.[mode] || designJson.tokens?.colors?.light || {};
+
+  return {
+    slug,
+    name: designJson.name,
+    categories: designJson.categories || [],
+    colors: {
+      primary: colors.primary || '',
+      secondary: colors.secondary || '',
+    },
+    defaultMode: designJson.defaultMode || 'light',
+    jsonUrl: `${GITHUB_PAGES_BASE}/designs/${slug}.json`,
+    thumbnailUrl: designJson.preview?.thumbnail 
+      ? `${GITHUB_PAGES_BASE}${designJson.preview.thumbnail}`
+      : `${GITHUB_PAGES_BASE}/previews/${slug}-thumb.svg`,
+    detailUrl: `/designs/${slug}`,
+  };
+};
+
+const designs = [
+  transformDesign(neoBrutalist),
+  transformDesign(warmSaas),
+  transformDesign(editorialDark),
+];
+
+export default designs;


### PR DESCRIPTION
Closes #19

## Summary

Created the central design index file `src/data/designs.js` that imports all design JSONs and exports them as a structured array for the catalog website.

## Approach

Balanced approach: Created a clean transformation function that extracts the required fields from each design JSON and formats them for the catalog.

## Changes

| File | Change |
|------|--------|
| `src/data/designs.js` | New design index file with all 3 designs |

## Test Results

- Build: passed
- Design validation: passed (3 designs validated)

## Acceptance Criteria

- [x] File at `src/data/designs.js`
- [x] Imports all JSON files from `public/designs/`
- [x] Exports array of design objects with: `slug`, `name`, `categories`, `colors.primary`, `colors.secondary`, `defaultMode`, `jsonUrl`, `thumbnailUrl`, `detailUrl`
- [x] `jsonUrl` resolves to the GitHub Pages URL
- [x] Adding a new design JSON + entry to this file is the only step needed to add it to the catalog