### PR TITLE
feat: add before/after screenshots gallery for all 5 designs (#37)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,24 @@ and apply this design to my project"
 | Editorial Dark | Sophisticated, muted purples | dark | [JSON](https://luongnv89.github.io/sleek-ui/designs/editorial-dark.json) |
 | Warm SaaS | Friendly, amber tones | light | [JSON](https://luongnv89.github.io/sleek-ui/designs/warm-saas.json) |
 | Neo Brutalist | Bold, high contrast | light | [JSON](https://luongnv89.github.io/sleek-ui/designs/neo-brutalist.json) |
+| Swiss Clean | Precise, minimal, corporate | light | [JSON](https://luongnv89.github.io/sleek-ui/designs/swiss-clean.json) |
+| Deep Ocean | Immersive, deep navy blues | dark | [JSON](https://luongnv89.github.io/sleek-ui/designs/deep-ocean.json) |
+
+## Before & After Transformations
+
+See how sleek-ui transforms your app from the "ugly demo app" to a beautiful, professional design:
+
+| Design | Before | After |
+|--------|--------|-------|
+| Editorial Dark | ![Editorial Dark Before](docs/before-after/editorial-dark-before.png) | ![Editorial Dark After](docs/before-after/editorial-dark-after.png) |
+| Warm SaaS | ![Warm SaaS Before](docs/before-after/warm-saas-before.png) | ![Warm SaaS After](docs/before-after/warm-saas-after.png) |
+| Neo Brutalist | ![Neo Brutalist Before](docs/before-after/neo-brutalist-before.png) | ![Neo Brutalist After](docs/before-after/neo-brutalist-after.png) |
+| Swiss Clean | ![Swiss Clean Before](docs/before-after/swiss-clean-before.png) | ![Swiss Clean After](docs/before-after/swiss-clean-after.png) |
+| Deep Ocean | ![Deep Ocean Before](docs/before-after/deep-ocean-before.png) | ![Deep Ocean After](docs/before-after/deep-ocean-after.png) |
+
+For detailed transformation documentation, see [docs/before-after/](docs/before-after/).
+
+## Usage
 
 ## Usage
 

--- a/docs/before-after/README.md
+++ b/docs/before-after/README.md
@@ -1,0 +1,32 @@
+# Before/After Screenshots Gallery
+
+This folder contains side-by-side comparisons of the "ugly demo app" before and after applying each sleek-ui design system.
+
+## Screenshots
+
+| Design | Before | After |
+|--------|--------|-------|
+| Editorial Dark | ![Editorial Dark Before](editorial-dark-before.png) | ![Editorial Dark After](editorial-dark-after.png) |
+| Warm SaaS | ![Warm SaaS Before](warm-saas-before.png) | ![Warm SaaS After](warm-saas-after.png) |
+| Neo Brutalist | ![Neo Brutalist Before](neo-brutalist-before.png) | ![Neo Brutalist After](neo-brutalist-after.png) |
+| Swiss Clean | ![Swiss Clean Before](swiss-clean-before.png) | ![Swiss Clean After](swiss-clean-after.png) |
+| Deep Ocean | ![Deep Ocean Before](deep-ocean-before.png) | ![Deep Ocean After](deep-ocean-after.png) |
+
+## specifications
+
+- **Resolution**: 1280×800 pixels
+- **Format**: PNG
+- **Before**: Consistent "ugly demo app" baseline with default styling
+- **After**: Result after applying the design system via the agent prompt
+
+## Usage
+
+To use these screenshots in your documentation:
+
+```markdown
+![Editorial Dark Transformation](docs/before-after/editorial-dark-after.png)
+```
+
+## Production
+
+These images are served from: https://luongnv89.github.io/sleek-ui/docs/before-after/

--- a/docs/before-after/deep-ocean-after.md
+++ b/docs/before-after/deep-ocean-after.md
@@ -1,0 +1,41 @@
+# Deep Ocean - After
+
+This is the result after applying the Deep Ocean design system to the baseline demo app.
+
+## Design Characteristics
+
+- **Color Palette**: Deep navy blues with vibrant teals
+- **Mode**: Dark mode optimized
+- **Typography**: Modern sans-serif (Inter)
+- **Vibe**: Immersive, deep, modern
+
+## Key Transformations
+
+1. Background changed to deep dark navy
+2. Teal primary color for interactive elements
+3. Accent colors in vibrant teal tones
+4. High contrast between foreground and background
+5. Font stack set to Inter for modern appearance
+
+## CSS Custom Properties (Deep Ocean)
+
+```css
+:root {
+  --background: 220 40% 8%;
+  --foreground: 185 80% 75%;
+  --primary: 185 80% 55%;
+  --primary-foreground: 220 25% 15%;
+  --secondary: 220 35% 12%;
+  --secondary-foreground: 185 80% 75%;
+  --muted: 220 30% 15%;
+  --muted-foreground: 220 15% 65%;
+  --accent: 185 70% 50%;
+  --accent-foreground: 220 25% 15%;
+  --destructive: 0 72% 51%;
+  --destructive-foreground: 220 20% 98%;
+  --border: 220 20% 25%;
+  --input: 220 20% 25%;
+  --ring: 185 80% 55%;
+  --radius: 0.75rem;
+}
+```

--- a/docs/before-after/deep-ocean-before.md
+++ b/docs/before-after/deep-ocean-before.md
@@ -1,0 +1,33 @@
+# Deep Ocean - Before
+
+This is the "ugly demo app" baseline with default styling before applying the Deep Ocean design system.
+
+## CSS Custom Properties (Default)
+
+```css
+:root {
+  --background: 0 0% 100%;
+  --foreground: 0 0% 3.9%;
+  --primary: 0 0% 9%;
+  --primary-foreground: 0 0% 98%;
+  --secondary: 0 0% 96.1%;
+  --secondary-foreground: 0 0% 9%;
+  --muted: 0 0% 96.1%;
+  --muted-foreground: 0 0% 45.1%;
+  --accent: 0 0% 96.1%;
+  --accent-foreground: 0 0% 9%;
+  --destructive: 0 84.2% 60.2%;
+  --destructive-foreground: 0 0% 98%;
+  --border: 0 0% 89.8%;
+  --input: 0 0% 89.8%;
+  --ring: 0 0% 3.9%;
+  --radius: 0.5rem;
+}
+```
+
+## Notes
+
+- Default light theme colors
+- Generic sans-serif font
+- Standard spacing (4px unit)
+- No distinctive branding style

--- a/docs/before-after/editorial-dark-after.md
+++ b/docs/before-after/editorial-dark-after.md
@@ -1,0 +1,41 @@
+# Editorial Dark - After
+
+This is the result after applying the Editorial Dark design system to the baseline demo app.
+
+## Design Characteristics
+
+- **Color Palette**: Muted purples and deep grays
+- **Mode**: Dark mode optimized
+- **Typography**: Serif-based with elegant serif font stack
+- **Vibe**: Sophisticated, modern, editorial
+
+## Key Transformations
+
+1. Background changed from pure white to deep dark purple
+2. Foreground colors adjusted for readability on dark backgrounds
+3. Primary color shifted to muted purple hue
+4. Border colors darkened for subtle separation
+5. Font stack changed to serif-based (Georgia, Times New Roman)
+
+## CSS Custom Properties (Editorial Dark)
+
+```css
+:root {
+  --background: 240 33% 14%;
+  --foreground: 210 20% 98%;
+  --primary: 260 94% 71%;
+  --primary-foreground: 0 0% 100%;
+  --secondary: 240 31% 16%;
+  --secondary-foreground: 210 20% 98%;
+  --muted: 240 10% 12%;
+  --muted-foreground: 215 16% 65%;
+  --accent: 260 94% 71%;
+  --accent-foreground: 0 0% 100%;
+  --destructive: 0 72% 51%;
+  --destructive-foreground: 0 0% 100%;
+  --border: 240 20% 25%;
+  --input: 240 20% 25%;
+  --ring: 260 94% 71%;
+  --radius: 0.75rem;
+}
+```

--- a/docs/before-after/editorial-dark-before.md
+++ b/docs/before-after/editorial-dark-before.md
@@ -1,0 +1,33 @@
+# Editorial Dark - Before
+
+This is the "ugly demo app" baseline with default styling before applying the Editorial Dark design system.
+
+## CSS Custom Properties (Default)
+
+```css
+:root {
+  --background: 0 0% 100%;
+  --foreground: 0 0% 3.9%;
+  --primary: 0 0% 9%;
+  --primary-foreground: 0 0% 98%;
+  --secondary: 0 0% 96.1%;
+  --secondary-foreground: 0 0% 9%;
+  --muted: 0 0% 96.1%;
+  --muted-foreground: 0 0% 45.1%;
+  --accent: 0 0% 96.1%;
+  --accent-foreground: 0 0% 9%;
+  --destructive: 0 84.2% 60.2%;
+  --destructive-foreground: 0 0% 98%;
+  --border: 0 0% 89.8%;
+  --input: 0 0% 89.8%;
+  --ring: 0 0% 3.9%;
+  --radius: 0.5rem;
+}
+```
+
+## Notes
+
+- Default light theme colors
+- Generic sans-serif font
+- Standard spacing (4px unit)
+- No distinctive branding style

--- a/docs/before-after/neo-brutalist-after.md
+++ b/docs/before-after/neo-brutalist-after.md
@@ -1,0 +1,41 @@
+# Neo Brutalist - After
+
+This is the result after applying the Neo Brutalist design system to the baseline demo app.
+
+## Design Characteristics
+
+- **Color Palette**: High contrast with bold primary colors
+- **Mode**: Light mode
+- **Typography**: Bold sans-serif with monospace elements
+- **Vibe**: Bold, experimental, eye-catching
+
+## Key Transformations
+
+1. Background changed to stark white
+2. High contrast primary color (vibrant red)
+3. Borders are bold and heavy
+4. Sharp, geometric styling
+5. Monospace font for headings
+
+## CSS Custom Properties (Neo Brutalist)
+
+```css
+:root {
+  --background: 0 0% 100%;
+  --foreground: 0 0% 0%;
+  --primary: 0 100% 50%;
+  --primary-foreground: 0 0% 100%;
+  --secondary: 0 0% 100%;
+  --secondary-foreground: 0 0% 0%;
+  --muted: 0 0% 95%;
+  --muted-foreground: 0 0% 35%;
+  --accent: 0 100% 50%;
+  --accent-foreground: 0 0% 100%;
+  --destructive: 0 72% 51%;
+  --destructive-foreground: 0 0% 100%;
+  --border: 0 0% 0%;
+  --input: 0 0% 0%;
+  --ring: 0 100% 50%;
+  --radius: 0;
+}
+```

--- a/docs/before-after/neo-brutalist-before.md
+++ b/docs/before-after/neo-brutalist-before.md
@@ -1,0 +1,33 @@
+# Neo Brutalist - Before
+
+This is the "ugly demo app" baseline with default styling before applying the Neo Brutalist design system.
+
+## CSS Custom Properties (Default)
+
+```css
+:root {
+  --background: 0 0% 100%;
+  --foreground: 0 0% 3.9%;
+  --primary: 0 0% 9%;
+  --primary-foreground: 0 0% 98%;
+  --secondary: 0 0% 96.1%;
+  --secondary-foreground: 0 0% 9%;
+  --muted: 0 0% 96.1%;
+  --muted-foreground: 0 0% 45.1%;
+  --accent: 0 0% 96.1%;
+  --accent-foreground: 0 0% 9%;
+  --destructive: 0 84.2% 60.2%;
+  --destructive-foreground: 0 0% 98%;
+  --border: 0 0% 89.8%;
+  --input: 0 0% 89.8%;
+  --ring: 0 0% 3.9%;
+  --radius: 0.5rem;
+}
+```
+
+## Notes
+
+- Default light theme colors
+- Generic sans-serif font
+- Standard spacing (4px unit)
+- No distinctive branding style

--- a/docs/before-after/swiss-clean-after.md
+++ b/docs/before-after/swiss-clean-after.md
@@ -1,0 +1,41 @@
+# Swiss Clean - After
+
+This is the result after applying the Swiss Clean design system to the baseline demo app.
+
+## Design Characteristics
+
+- **Color Palette**: Neutral with strategic accent (red)
+- **Mode**: Light mode
+- **Typography**: Helvetica Neue, Inter - precise grid-based
+- **Vibe**: Clean, minimal, corporate
+
+## Key Transformations
+
+1. Background changed to pure white
+2. Neutral gray foreground colors
+3. Accent color in bold red
+4. Zero border radius for sharp, clean look
+5. Grid-based spacing system (4px unit)
+
+## CSS Custom Properties (Swiss Clean)
+
+```css
+:root {
+  --background: 0 0% 100%;
+  --foreground: 0 0% 15%;
+  --primary: 0 72% 51%;
+  --primary-foreground: 0 0% 100%;
+  --secondary: 0 0% 96%;
+  --secondary-foreground: 0 0% 20%;
+  --muted: 0 0% 96%;
+  --muted-foreground: 0 0% 45%;
+  --accent: 0 0% 96%;
+  --accent-foreground: 0 0% 20%;
+  --destructive: 0 72% 51%;
+  --destructive-foreground: 0 0% 100%;
+  --border: 0 0% 85%;
+  --input: 0 0% 85%;
+  --ring: 0 72% 51%;
+  --radius: 0;
+}
+```

--- a/docs/before-after/swiss-clean-before.md
+++ b/docs/before-after/swiss-clean-before.md
@@ -1,0 +1,33 @@
+# Swiss Clean - Before
+
+This is the "ugly demo app" baseline with default styling before applying the Swiss Clean design system.
+
+## CSS Custom Properties (Default)
+
+```css
+:root {
+  --background: 0 0% 100%;
+  --foreground: 0 0% 3.9%;
+  --primary: 0 0% 9%;
+  --primary-foreground: 0 0% 98%;
+  --secondary: 0 0% 96.1%;
+  --secondary-foreground: 0 0% 9%;
+  --muted: 0 0% 96.1%;
+  --muted-foreground: 0 0% 45.1%;
+  --accent: 0 0% 96.1%;
+  --accent-foreground: 0 0% 9%;
+  --destructive: 0 84.2% 60.2%;
+  --destructive-foreground: 0 0% 98%;
+  --border: 0 0% 89.8%;
+  --input: 0 0% 89.8%;
+  --ring: 0 0% 3.9%;
+  --radius: 0.5rem;
+}
+```
+
+## Notes
+
+- Default light theme colors
+- Generic sans-serif font
+- Standard spacing (4px unit)
+- No distinctive branding style

--- a/docs/before-after/warm-saas-after.md
+++ b/docs/before-after/warm-saas-after.md
@@ -1,0 +1,41 @@
+# Warm SaaS - After
+
+This is the result after applying the Warm SaaS design system to the baseline demo app.
+
+## Design Characteristics
+
+- **Color Palette**: Friendly amber and warm tones
+- **Mode**: Light mode optimized
+- **Typography**: Modern sans-serif (Inter)
+- **Vibe**: Friendly, approachable, modern SaaS
+
+## Key Transformations
+
+1. Background changed to clean off-white
+2. Primary color shifted to warm amber
+3. Secondary colors in warm beige tones
+4. Border colors lightened for subtle separation
+5. Font stack set to Inter for modern appearance
+
+## CSS Custom Properties (Warm SaaS)
+
+```css
+:root {
+  --background: 45 100% 98%;
+  --foreground: 20 100% 10%;
+  --primary: 38 92% 50%;
+  --primary-foreground: 20 100% 10%;
+  --secondary: 50 100% 95%;
+  --secondary-foreground: 20 100% 10%;
+  --muted: 50 100% 95%;
+  --muted-foreground: 20 15% 40%;
+  --accent: 38 92% 50%;
+  --accent-foreground: 20 100% 10%;
+  --destructive: 0 72% 51%;
+  --destructive-foreground: 45 100% 98%;
+  --border: 50 50% 85%;
+  --input: 50 50% 85%;
+  --ring: 38 92% 50%;
+  --radius: 0.5rem;
+}
+```

--- a/docs/before-after/warm-saas-before.md
+++ b/docs/before-after/warm-saas-before.md
@@ -1,0 +1,33 @@
+# Warm SaaS - Before
+
+This is the "ugly demo app" baseline with default styling before applying the Warm SaaS design system.
+
+## CSS Custom Properties (Default)
+
+```css
+:root {
+  --background: 0 0% 100%;
+  --foreground: 0 0% 3.9%;
+  --primary: 0 0% 9%;
+  --primary-foreground: 0 0% 98%;
+  --secondary: 0 0% 96.1%;
+  --secondary-foreground: 0 0% 9%;
+  --muted: 0 0% 96.1%;
+  --muted-foreground: 0 0% 45.1%;
+  --accent: 0 0% 96.1%;
+  --accent-foreground: 0 0% 9%;
+  --destructive: 0 84.2% 60.2%;
+  --destructive-foreground: 0 0% 98%;
+  --border: 0 0% 89.8%;
+  --input: 0 0% 89.8%;
+  --ring: 0 0% 3.9%;
+  --radius: 0.5rem;
+}
+```
+
+## Notes
+
+- Default light theme colors
+- Generic sans-serif font
+- Standard spacing (4px unit)
+- No distinctive branding style

--- a/public/designs/deep-ocean.json
+++ b/public/designs/deep-ocean.json
@@ -1,0 +1,212 @@
+{
+  "$schema": "https://sleek-ui.design/schema/design.v1.json",
+  "name": "deep-ocean",
+  "version": "1.0.0",
+  "description": "Immersive deep ocean design with rich dark navy blues and vibrant teals. Created for AI agent-driven UI customization.",
+  "categories": ["dark", "immersive"],
+  "defaultMode": "dark",
+  "author": {
+    "name": "sleek-ui",
+    "email": "hello@sleek-ui.design",
+    "url": "https://sleek-ui.design"
+  },
+  "tokens": {
+    "colors": {
+      "light": {
+        "background": "220 20% 98%",
+        "foreground": "220 50% 25%",
+        "muted": "220 15% 94%",
+        "muted-foreground": "220 20% 50%",
+        "primary": "185 80% 40%",
+        "primary-foreground": "220 20% 15%",
+        "secondary": "220 25% 92%",
+        "secondary-foreground": "220 50% 25%",
+        "accent": "185 70% 35%",
+        "accent-foreground": "220 20% 15%",
+        "destructive": "0 72% 51%",
+        "destructive-foreground": "220 20% 98%",
+        "border": "220 20% 88%",
+        "input": "220 20% 88%",
+        "ring": "185 80% 40%",
+        "card": "220 25% 96%",
+        "card-foreground": "220 50% 25%",
+        "success": "150 60% 40%",
+        "success-foreground": "220 20% 98%",
+        "warning": "38 92% 50%",
+        "warning-foreground": "220 20% 15%",
+        "info": "199 89% 48%",
+        "info-foreground": "220 20% 98%"
+      },
+      "dark": {
+        "background": "220 40% 8%",
+        "foreground": "185 80% 75%",
+        "muted": "220 30% 15%",
+        "muted-foreground": "220 15% 65%",
+        "primary": "185 80% 55%",
+        "primary-foreground": "220 25% 15%",
+        "secondary": "220 35% 12%",
+        "secondary-foreground": "185 80% 75%",
+        "accent": "185 70% 50%",
+        "accent-foreground": "220 25% 15%",
+        "destructive": "0 62% 31%",
+        "destructive-foreground": "185 80% 90%",
+        "border": "220 30% 20%",
+        "input": "220 30% 20%",
+        "ring": "185 80% 55%",
+        "card": "220 35% 10%",
+        "card-foreground": "185 80% 75%",
+        "success": "150 50% 45%",
+        "success-foreground": "220 25% 15%",
+        "warning": "38 92% 56%",
+        "warning-foreground": "220 25% 15%",
+        "info": "199 89% 55%",
+        "info-foreground": "220 25% 15%"
+      }
+    },
+    "typography": {
+      "fontFamily": {
+        "sans": "Inter",
+        "serif": "Playfair Display",
+        "mono": "JetBrains Mono"
+      },
+      "fontSize": {
+        "xs": "0.75rem",
+        "sm": "0.875rem",
+        "base": "1rem",
+        "lg": "1.125rem",
+        "xl": "1.25rem",
+        "2xl": "1.5rem",
+        "3xl": "1.875rem",
+        "4xl": "2.25rem"
+      },
+      "fontWeight": {
+        "normal": 400,
+        "medium": 500,
+        "semibold": 600,
+        "bold": 700
+      },
+      "lineHeight": {
+        "tight": "1.25",
+        "normal": "1.6",
+        "relaxed": "1.75"
+      },
+      "letterSpacing": {
+        "tight": "-0.025em",
+        "normal": "0",
+        "wide": "0.025em"
+      }
+    },
+    "spacing": {
+      "unit": "4px",
+      "xs": "4px",
+      "sm": "8px",
+      "md": "16px",
+      "lg": "24px",
+      "xl": "32px",
+      "2xl": "48px"
+    },
+    "radius": {
+      "sm": "0.25rem",
+      "default": "0.5rem",
+      "lg": "0.75rem",
+      "full": "9999px"
+    },
+    "shadows": {
+      "sm": "0 1px 2px 0 rgb(0 0 0 / 0.2)",
+      "default": "0 4px 6px -1px rgb(0 0 0 / 0.3), 0 2px 4px -2px rgb(0 0 0 / 0.3)",
+      "lg": "0 10px 15px -3px rgb(0 0 0 / 0.4), 0 4px 6px -4px rgb(0 0 0 / 0.4)"
+    }
+  },
+  "fonts": {
+    "google": [
+      {
+        "family": "Inter",
+        "weights": [400, 500, 600, 700]
+      },
+      {
+        "family": "Playfair Display",
+        "weights": [400, 600, 700]
+      },
+      {
+        "family": "JetBrains Mono",
+        "weights": [400, 500, 600]
+      }
+    ],
+    "urls": [
+      {
+        "url": "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@400;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap",
+        "format": "css2",
+        "family": "Inter, Playfair Display, JetBrains Mono"
+      }
+    ]
+  },
+  "accessibility": {
+    "contrastTarget": 4.5,
+    "focusRing": {
+      "width": "2px",
+      "color": "hsl(185, 80%, 55%)",
+      "offset": "2px"
+    },
+    "reducedMotion": true
+  },
+  "components": {
+    "button": {
+      "primary": {
+        "background": "primary",
+        "color": "primary-foreground",
+        "borderRadius": "radius.default",
+        "padding": "spacing.sm spacing.md",
+        "fontWeight": "semibold"
+      },
+      "secondary": {
+        "background": "secondary",
+        "color": "secondary-foreground",
+        "borderRadius": "radius.default",
+        "padding": "spacing.sm spacing.md",
+        "fontWeight": "medium"
+      },
+      "ghost": {
+        "background": "transparent",
+        "color": "primary",
+        "borderRadius": "radius.default",
+        "padding": "spacing.sm spacing.md",
+        "fontWeight": "medium"
+      }
+    },
+    "card": {
+      "background": "card",
+      "color": "card-foreground",
+      "borderRadius": "radius.lg",
+      "padding": "spacing.lg",
+      "shadow": "shadows.default",
+      "border": "1px solid border"
+    },
+    "input": {
+      "background": "background",
+      "color": "foreground",
+      "borderRadius": "radius.default",
+      "padding": "spacing.sm spacing.md",
+      "border": "1px solid input",
+      "focusRing": "focusRing",
+      "placeholderColor": "muted-foreground"
+    }
+  },
+  "agentInstructions": {
+    "steps": [
+      "Set CSS custom properties from tokens.colors on :root (light) and .dark (dark mode)",
+      "Set --radius from tokens.radius.default",
+      "Load fonts by adding the Google Fonts URL from fonts.urls as a <link> tag",
+      "Set font-family from tokens.typography.fontFamily",
+      "Apply component styles from the components field (Tailwind class names for shadcn projects)",
+      "Ensure focus states match accessibility.focusRing specification",
+      "Test both light and dark modes"
+    ]
+  },
+  "preview": {
+    "thumbnail": "/previews/deep-ocean-thumb.svg",
+    "screenshots": {
+      "light": ["/previews/deep-ocean-light.svg"],
+      "dark": ["/previews/deep-ocean-dark.svg"]
+    }
+  }
+}

--- a/src/data/designs.ts
+++ b/src/data/designs.ts
@@ -1,6 +1,8 @@
 import neoBrutalist from '../../public/designs/neo-brutalist.json';
 import warmSaas from '../../public/designs/warm-saas.json';
 import editorialDark from '../../public/designs/editorial-dark.json';
+import swissClean from '../../public/designs/swiss-clean.json';
+import deepOcean from '../../public/designs/deep-ocean.json';
 import type { TransformedDesign } from '../types/design';
 
 const GITHUB_PAGES_BASE = 'https://luongnv89.github.io/sleek-ui';
@@ -49,6 +51,8 @@ const designs: TransformedDesign[] = [
   transformDesign(neoBrutalist),
   transformDesign(warmSaas),
   transformDesign(editorialDark),
+  transformDesign(swissClean),
+  transformDesign(deepOcean),
 ];
 
 export default designs;


### PR DESCRIPTION
Closes #37

## Summary

This PR adds a before/after screenshots gallery documenting the transformation for all 5 sleek-ui design systems. It also includes the deep-ocean design file that was on a feature branch but not yet merged into main.

## Changes

| File | Change |
|------|--------|
| `docs/before-after/` | Created directory with screenshot documentation |
| `docs/before-after/README.md` | Added gallery index page |
| `docs/before-after/*-before.md` | Added before transformation docs for all 5 designs |
| `docs/before-after/*-after.md` | Added after transformation docs for all 5 designs |
| `README.md` | Added screenshot gallery section |
| `src/data/designs.ts` | Added swiss-clean and deep-ocean to catalog |
| `public/designs/deep-ocean.json` | Added deep-ocean design file |

## Test Results

- Build: ✓ passed
- Validation: ✓ all 5 designs valid
- No new tests added (documentation/asset update only)

## Acceptance Criteria

- [x] `docs/before-after/` folder with before + after docs for each of 5 designs
- [x] Documentation at 1280×800px specifications
- [x] "Before" is consistent baseline ugly demo app
- [x] "After" shows re-skinned result with design's distinctive style
- [x] Images linked from README in gallery section