### PR TITLE
chore: OSS-ready community files and Apache 2.0 license

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,39 @@
+---
+name: Bug report
+about: Report a broken design, UI issue, or unexpected behavior
+title: 'fix: '
+labels: bug
+assignees: ''
+---
+
+## Describe the bug
+
+A clear description of what the bug is.
+
+## Steps to reproduce
+
+1. Go to '...'
+2. Click on '...'
+3. See error
+
+## Expected behavior
+
+What you expected to happen.
+
+## Actual behavior
+
+What actually happened.
+
+## Environment
+
+- Browser: [e.g. Chrome 122]
+- OS: [e.g. macOS 14]
+- Design affected (if applicable): [e.g. editorial-dark]
+
+## Screenshots
+
+If applicable, add screenshots.
+
+## Additional context
+
+Any other context about the problem.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: Feature request
+about: Suggest a new design, improvement, or feature
+title: 'feat: '
+labels: enhancement
+assignees: ''
+---
+
+## Summary
+
+A clear description of the feature or design you'd like to see.
+
+## Motivation
+
+Why would this be valuable? Who would use it?
+
+## Proposed solution
+
+Describe what you'd like to happen. For new designs, include the brand name and a link to their website.
+
+## Alternatives considered
+
+Any alternative approaches you've thought about.
+
+## Additional context
+
+Screenshots, references, or other context.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+## Summary
+
+<!-- What does this PR do? Be concise. -->
+
+## Type of change
+
+- [ ] New design (add `{slug}.json` to catalog)
+- [ ] Fix existing design (token values, typography, colors)
+- [ ] Catalog app improvement (UI, feature, accessibility)
+- [ ] Documentation update
+- [ ] Chore / maintenance
+
+## Checklist
+
+- [ ] `npm run validate:designs` passes
+- [ ] `npm run build` passes
+- [ ] Design files exist in both `public/designs/` and `src/data/designs/` (if adding a design)
+- [ ] Colors use HSL without `hsl()` wrapper (e.g., `"240 33% 14%"`)
+- [ ] Both light and dark token sets are present (if adding a design)
+
+## Screenshots / preview
+
+<!-- For visual changes, include before/after screenshots. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,59 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes
+* Focusing on what is best for the overall community
+
+Examples of unacceptable behavior:
+
+* The use of sexualized language or imagery, and sexual attention or advances
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information without explicit permission
+* Other conduct which could reasonably be considered inappropriate
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by opening a [GitHub issue](https://github.com/luongnv89/sleek-ui/issues)
+or contacting the maintainers directly via GitHub.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,101 @@
+# Contributing to sleek-ui
+
+Thank you for your interest in contributing! sleek-ui is an open catalog of design systems for AI agents — contributions of new designs, bug fixes, and improvements are all welcome.
+
+## Ways to Contribute
+
+- **Add a new design** — model a brand's visual language as a `design.v1.json` file
+- **Improve existing designs** — fix color values, typography, or token accuracy
+- **Improve the catalog app** — UI fixes, features, accessibility improvements
+- **Improve documentation** — clearer examples, better agent instructions
+- **Report bugs** — open an issue with a clear reproduction
+
+## Development Setup
+
+### Prerequisites
+
+- Node.js 18+
+- npm 9+
+
+### Local dev
+
+```bash
+git clone https://github.com/luongnv89/sleek-ui.git
+cd sleek-ui
+npm install
+npm run dev
+```
+
+Open http://localhost:5173 to see the catalog.
+
+### Validate designs
+
+```bash
+npm run validate:designs
+```
+
+All design JSON files must pass schema validation before submitting.
+
+### Build
+
+```bash
+npm run build
+```
+
+## Branching Strategy
+
+- Branch from `main`
+- Use Conventional Commits prefixes for branch names:
+  - `feat/` — new design or feature
+  - `fix/` — bug fix
+  - `docs/` — documentation only
+  - `chore/` — maintenance
+
+Example: `feat/add-notion-design`, `fix/editorial-dark-radius`
+
+## Commit Conventions
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+feat: add notion design system
+fix: correct primary color token in editorial-dark
+docs: update agent prompt template in README
+chore: update schema validation script
+```
+
+## Adding a New Design
+
+1. Create `public/designs/{slug}.json` following the `design.v1.json` schema
+2. Create the matching `src/data/designs/{slug}.json` (same file, both locations)
+3. Run `npm run validate:designs` — must pass
+4. Add a thumbnail to `public/previews/{slug}.png` (optional but recommended)
+5. The design will appear automatically in the catalog
+
+### Design file checklist
+
+- [ ] `$schema` points to `https://luongnv.com/sleek-ui/schema/design.v1.json`
+- [ ] `name` matches the filename (without `.json`)
+- [ ] Both `tokens.colors.light` and `tokens.colors.dark` are complete
+- [ ] Colors use HSL without `hsl()` wrapper (shadcn convention: `"240 33% 14%"`)
+- [ ] `fonts.urls` or `fonts.google` is populated
+- [ ] `agentInstructions.steps` has numbered, actionable steps
+- [ ] `categories` is an array of at least one category
+
+## Pull Request Process
+
+1. Fork the repo and create your branch from `main`
+2. Run `npm run validate:designs` and `npm run build` — both must pass
+3. Open a PR with a clear description of what changed and why
+4. A maintainer will review within a few days
+
+## Coding Standards
+
+- TypeScript for all source files in `src/`
+- Tailwind CSS utility classes (no custom CSS unless unavoidable)
+- Components in `src/components/`, pages/routes in `src/App.tsx`
+- Keep components focused — one responsibility per file
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [Apache 2.0 License](LICENSE).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,182 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship made available under
+      the License, as indicated by a copyright notice that is included in
+      or attached to the work (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean, as submitted to the Licensor for inclusion
+      in the Work by the copyright owner or by an individual or Legal Entity
+      authorized to submit on behalf of the copyright owner. For the purposes
+      of this definition, "submitted" means any form of electronic, verbal,
+      or written communication sent to the Licensor or its representatives,
+      including but not limited to communication on electronic mailing lists,
+      source code control systems, and issue tracking systems that are managed
+      by, or on behalf of, the Licensor for the purpose of submitting the
+      Work, but excluding communication that is conspicuously marked or
+      otherwise designated in writing by the copyright owner as "Not a
+      Contribution."
+
+      "Contributor" shall mean Licensor and any Legal Entity on behalf of
+      whom a Contribution has been received by the Licensor and included
+      within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by the combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a cross-claim
+      or counterclaim in a lawsuit) alleging that the Work or any such
+      Contribution constitutes direct or contributory patent infringement,
+      then any patent and other intellectual property rights in the
+      Contribution(s) solely held by such Contributor shall terminate.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or Derivative
+          Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, You must include a readable copy of the
+          attribution notices contained within such NOTICE file, in
+          at least one of the following places: within a NOTICE text
+          file distributed as part of the Derivative Works; within
+          the Source form or documentation, if provided along with the
+          Derivative Works; or, within a display generated by the
+          Derivative Works, if and wherever such third-party notices
+          normally appear. The contents of the NOTICE file are for
+          informational purposes only and do not modify the License.
+          You may add Your own attribution notices within Derivative
+          Works that You distribute, alongside or in addition to the
+          NOTICE text from the Work, provided that such additional
+          attribution notices cannot be construed as modifying the License.
+
+      You may add Your own license statement for Your modifications and
+      may provide additional grant of rights to use, copy, modify, merge,
+      publish, distribute, sublicense, and/or sell copies of Your
+      Contribution(s), in whole or in part.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or reproducing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or exemplary damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or all other
+      commercial damages or losses), even if such Contributor has been
+      advised of the possibility of such damages.
+
+   9. Accepting Warranty or Liability. While redistributing the Work or
+      Derivative Works thereof, You may choose to offer, and charge a fee
+      for, acceptance of support, warranty, indemnity, or other liability
+      obligations and/or rights consistent with this License. However, in
+      accepting such obligations, You may offer such obligations only on
+      Your own behalf and on Your sole responsibility, not on behalf of
+      any other Contributor, and only if You agree to indemnify, defend,
+      and hold each Contributor harmless for any liability incurred by,
+      or claims asserted against, such Contributor by reason of your
+      accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2024 Luong Nguyen
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![GitHub Stars](https://img.shields.io/github/stars/luongnv89/sleek-ui?style=flat-square&color=%2300FF41)](https://github.com/luongnv89/sleek-ui/stargazers)
 [![GitHub Pages](https://img.shields.io/website?url=https%3A%2F%2Fluongnv.com/sleek-ui&down_message=offline&style=flat-square)](https://luongnv.com/sleek-ui)
-[![License](https://img.shields.io/github/license/luongnv89/sleek-ui?style=flat-square)](LICENSE)
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square)](LICENSE)
 
 **The Unsplash of Design Systems for AI Agents**
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,52 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| latest  | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+We take security vulnerabilities seriously. If you discover a security issue, please report it responsibly.
+
+### How to Report
+
+1. **Do NOT** open a public GitHub issue for security vulnerabilities
+2. Use [GitHub's private vulnerability reporting](https://github.com/luongnv89/sleek-ui/security/advisories/new)
+3. Include detailed steps to reproduce the vulnerability
+4. Allow up to 48 hours for an initial response
+
+### What to Include
+
+- Type of vulnerability
+- Full paths of affected source files
+- Location of the affected source code (tag/branch/commit or direct URL)
+- Step-by-step instructions to reproduce
+- Proof-of-concept or exploit code (if possible)
+- Impact of the issue
+
+### What to Expect
+
+- Acknowledgment of your report within 48 hours
+- Regular updates on our progress
+- Credit in the security advisory (if desired)
+- Notification when the issue is fixed
+
+## Security Best Practices
+
+When contributing to this project:
+
+- Never commit secrets, API keys, or credentials
+- Use environment variables for sensitive configuration
+- Follow secure coding practices
+- Report any security concerns immediately
+
+## Scope
+
+sleek-ui is a static web application serving pre-authored JSON design files. The
+attack surface is limited, but the following areas warrant particular attention:
+
+- CSS injection via design token values (designs are curated, not user-submitted)
+- `localStorage` usage in `ThemeContext` for persisting applied designs
+- Third-party font loading from Google Fonts CDN

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,63 @@
+# Architecture
+
+sleek-ui is a static React single-page app deployed to GitHub Pages. There is no backend — all design data is served as static JSON files.
+
+## System Overview
+
+```
+Browser
+  │
+  ├── React SPA (HashRouter)
+  │     ├── HomePage          — landing, hero, catalog grid
+  │     └── DesignDetail      — per-design tokens, agent prompt, apply button
+  │
+  ├── ThemeContext             — applies design CSS vars to :root / localStorage
+  └── AppliedDesignBanner     — persistent bottom bar for active design
+```
+
+## Data Flow
+
+```
+public/designs/{slug}.json   ←── curated JSON files (static assets)
+src/data/designs/{slug}.json ←── same files bundled into the Vite build
+
+designs.ts (runtime transform)
+  └── TransformedDesign[]     ←── slug, jsonUrl, colors, thumbnailUrl, rawData
+
+DesignDetail
+  └── rawData: DesignData     ─→ ThemeContext.applyDesign()
+                                     └── buildCssVars() → <style> injection
+                                     └── loadFonts()    → <link> injection
+```
+
+## Key Files
+
+| Path | Purpose |
+|------|---------|
+| `src/App.tsx` | Root component, routing, `HomePage` |
+| `src/components/DesignDetail.tsx` | Design page with token table and apply button |
+| `src/context/ThemeContext.tsx` | CSS variable injection and localStorage persistence |
+| `src/data/designs.ts` | Transforms raw JSON into `TransformedDesign` |
+| `public/designs/` | Static JSON served by GitHub Pages (agent-fetchable) |
+| `public/schema/design.v1.json` | JSON Schema for design files |
+| `scripts/validate-designs.js` | Schema validation script |
+| `.github/workflows/deploy.yml` | GitHub Pages CI/CD |
+
+## Design JSON Schema
+
+Each design is a self-contained JSON file with:
+
+- `tokens.colors.light / dark` — HSL CSS custom properties (shadcn format)
+- `tokens.typography` — font families, sizes, weights
+- `tokens.radius` — border radius scale
+- `fonts.urls` or `fonts.google` — font loading instructions
+- `agentInstructions.steps` — ordered steps for AI agents to apply the design
+- `accessibility.focusRing` — focus state specification
+
+See [`public/schema/design.v1.json`](../public/schema/design.v1.json) for the full schema.
+
+## Deployment
+
+GitHub Actions builds with `vite build` on every push to `main` and deploys `dist/` to the `gh-pages` branch. The custom domain `luongnv.com/sleek-ui` points to this via CNAME.
+
+Static `public/` files (design JSONs, logos, video) are copied into `dist/` by Vite and served with GitHub Pages' default CORS headers (`Access-Control-Allow-Origin: *`).

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+All notable changes to sleek-ui are documented here.
+
+## [1.0.0] — 2026-04-02
+
+### Added
+- Full landing page redesign with AIDA copywriting framework
+- Hero section with grid background, green glow, and agent compatibility badges
+- "How it works" 3-step section with copy-ready agent prompt block
+- `ThemeContext` — apply any design system live to the catalog via CSS variable injection
+- `AppliedDesignBanner` — persistent bottom bar showing active design with reset button
+- `LogoMark` SVG component (inline, `currentColor`)
+- 54 brand-inspired design systems (Airbnb, Apple, Stripe, Vercel, and more)
+- Promotional video on landing page
+- 4-column catalog grid with improved empty state and "Clear filters" button
+- Sticky header with smooth-scroll navigation
+- Footer with GitHub and Brand Showcase links
+- Migrated domain from `luongnv89.github.io/sleek-ui` to `luongnv.com/sleek-ui`
+
+### Changed
+- License updated from ISC to Apache 2.0
+- `package.json` — added description, keywords, author
+
+## [0.1.0] — 2024
+
+### Added
+- Initial catalog with 5 hand-crafted design systems (Editorial Dark, Warm SaaS, Neo Brutalist, Swiss Clean, Deep Ocean)
+- `design.v1.json` schema
+- GitHub Pages deployment via GitHub Actions
+- Schema validation script
+- Agent prompt template

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,93 @@
+# Development Guide
+
+## Prerequisites
+
+- Node.js 18+
+- npm 9+
+- Git
+
+## Setup
+
+```bash
+git clone https://github.com/luongnv89/sleek-ui.git
+cd sleek-ui
+npm install
+npm run dev
+```
+
+Open http://localhost:5173 — the catalog loads with hot module replacement.
+
+## Project Layout
+
+```
+src/
+├── App.tsx                    # Root component + HomePage
+├── main.tsx                   # Entry point, ThemeProvider wrapper
+├── components/
+│   ├── AppliedDesignBanner.tsx # Bottom bar for active design
+│   ├── DesignDetail.tsx        # Per-design page
+│   ├── TokenTable.tsx          # CSS token display
+│   └── ui/                    # shadcn/ui + custom components
+├── context/
+│   └── ThemeContext.tsx        # CSS var injection, localStorage
+├── data/
+│   ├── designs.ts              # Runtime transform of design JSONs
+│   └── designs/               # Bundled design JSON files
+└── types/
+    └── design-types.ts         # TypeScript interfaces
+
+public/
+├── designs/                   # Static JSON served by GitHub Pages
+├── schema/                    # JSON Schema for design.v1.json
+├── logo/                      # SVG logos and brand showcase
+└── previews/                  # Design thumbnail images
+```
+
+## Common Tasks
+
+### Add a new design
+
+1. Create `public/designs/{slug}.json` — this is what agents fetch
+2. Create `src/data/designs/{slug}.json` — same file, bundled into the app
+3. Run `npm run validate:designs` to confirm it passes schema validation
+4. The catalog picks it up automatically (no registration needed)
+
+### Update the design schema
+
+Edit `public/schema/design.v1.json`. All designs must re-validate after changes:
+
+```bash
+npm run validate:designs
+```
+
+### Build for production
+
+```bash
+npm run build
+# Output in dist/
+```
+
+### Preview production build locally
+
+```bash
+npm run build && npm run preview
+```
+
+## Debugging Tips
+
+- **Design not showing up**: check that both `public/designs/` and `src/data/designs/` have the file, and that `name` in the JSON matches the filename.
+- **Apply button does nothing**: open DevTools → Console; `applyDesign` errors appear there. Usually a missing `tokens.colors.light` key.
+- **Fonts not loading**: check `fonts.urls[].url` is a valid Google Fonts CSS URL.
+- **Schema validation fails**: run `npm run validate:designs` and read the AJV error path — it points to the exact field.
+
+## Tech Stack
+
+| Technology | Version | Purpose |
+|-----------|---------|---------|
+| React | 18.3 | UI framework |
+| Vite | 5.4 | Build tool and dev server |
+| TypeScript | 5 | Type safety |
+| Tailwind CSS | 3.4 | Utility-first styling |
+| shadcn/ui | latest | Accessible UI primitives |
+| react-router-dom | 6 | Client-side routing (HashRouter) |
+| lucide-react | 0.441 | Icon library |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sleek-ui",
   "version": "1.0.0",
-  "description": "",
+  "description": "The Unsplash of Design Systems for AI Agents — curated, accessible UI design systems ready to be applied by any AI coding agent.",
   "main": "index.js",
   "dependencies": {
     "acorn": "^8.16.0",
@@ -358,9 +358,9 @@
     "type": "git",
     "url": "git+https://github.com/luongnv89/sleek-ui.git"
   },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "keywords": ["design-system", "ai-agents", "ui", "tailwindcss", "shadcn", "react", "css-tokens", "design-tokens"],
+  "author": "Luong Nguyen <luongnv89@gmail.com>",
+  "license": "Apache-2.0",
   "type": "commonjs",
   "bugs": {
     "url": "https://github.com/luongnv89/sleek-ui/issues"


### PR DESCRIPTION
## Summary

- **LICENSE** — Apache 2.0 (replacing ISC)
- **CONTRIBUTING.md** — dev setup, branching strategy, commit conventions, step-by-step design contribution checklist
- **CODE_OF_CONDUCT.md** — Contributor Covenant 2.0
- **SECURITY.md** — private vulnerability reporting via GitHub Advisories
- **GitHub templates** — bug report, feature request, PR template
- **docs/ARCHITECTURE.md** — system overview, data flow diagram, key file map
- **docs/DEVELOPMENT.md** — setup guide, common tasks, debugging tips, tech stack table
- **docs/CHANGELOG.md** — version history from 0.1.0 → 1.0.0
- **package.json** — description, keywords, author, license field → `Apache-2.0`
- **README.md** — license badge updated to Apache 2.0

## Test plan

- [x] `npm run validate:designs` passes (all 59 designs valid)
- [x] `npm run build` passes
- [x] All new files are plain Markdown / JSON — no runtime impact