### PR TITLE
feat(seo): add Open Graph and Twitter Card meta tags (#80)

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,23 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/sleek-ui/logo/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="60+ production-grade design systems as one URL. Give your AI agent a URL and it applies colors, typography, spacing, and component styles automatically." />
+
+    <!-- Open Graph -->
+    <meta property="og:title" content="sleek-ui — Professional design systems for your AI agent" />
+    <meta property="og:description" content="60+ production-grade design systems as one URL. Give your AI agent a URL and it applies colors, typography, spacing, and component styles automatically." />
+    <meta property="og:image" content="https://luongnv.com/sleek-ui/sleek-ui-og.svg" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:url" content="https://luongnv.com/sleek-ui" />
+    <meta property="og:type" content="website" />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="sleek-ui — Professional design systems for your AI agent" />
+    <meta name="twitter:description" content="60+ production-grade design systems as one URL. Give your AI agent a URL and it applies colors, typography, spacing, and component styles automatically." />
+    <meta name="twitter:image" content="https://luongnv.com/sleek-ui/sleek-ui-og.svg" />
+
     <title>sleek-ui — Professional design systems for AI agents</title>
   </head>
   <body>

--- a/public/sleek-ui-og.svg
+++ b/public/sleek-ui-og.svg
@@ -55,7 +55,7 @@
   </g>
 
   <!-- Glow -->
-  <circle cx="600" cy="315" r="280" fill="#00FF41" opacity="0.06" filter="url(#blur)"/>
+  <circle cx="600" cy="315" r="280" fill="#00FF41" opacity="0.06"/>
 
   <!-- Logo mark -->
   <g transform="translate(72, 72)">

--- a/public/sleek-ui-og.svg
+++ b/public/sleek-ui-og.svg
@@ -1,0 +1,98 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0a0a0a"/>
+      <stop offset="100%" stop-color="#1a1a1a"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#00FF41"/>
+      <stop offset="100%" stop-color="#00cc33"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+
+  <!-- Grid pattern -->
+  <g opacity="0.04">
+    <line x1="0" y1="0" x2="1200" y2="0" stroke="#fff" stroke-width="0.5"/>
+    <line x1="0" y1="48" x2="1200" y2="48" stroke="#fff" stroke-width="0.5"/>
+    <line x1="0" y1="96" x2="1200" y2="96" stroke="#fff" stroke-width="0.5"/>
+    <line x1="0" y1="144" x2="1200" y2="144" stroke="#fff" stroke-width="0.5"/>
+    <line x1="0" y1="192" x2="1200" y2="192" stroke="#fff" stroke-width="0.5"/>
+    <line x1="0" y1="240" x2="1200" y2="240" stroke="#fff" stroke-width="0.5"/>
+    <line x1="0" y1="288" x2="1200" y2="288" stroke="#fff" stroke-width="0.5"/>
+    <line x1="0" y1="336" x2="1200" y2="336" stroke="#fff" stroke-width="0.5"/>
+    <line x1="0" y1="384" x2="1200" y2="384" stroke="#fff" stroke-width="0.5"/>
+    <line x1="0" y1="432" x2="1200" y2="432" stroke="#fff" stroke-width="0.5"/>
+    <line x1="0" y1="480" x2="1200" y2="480" stroke="#fff" stroke-width="0.5"/>
+    <line x1="0" y1="528" x2="1200" y2="528" stroke="#fff" stroke-width="0.5"/>
+    <line x1="0" y1="576" x2="1200" y2="576" stroke="#fff" stroke-width="0.5"/>
+    <line x1="0" y1="624" x2="1200" y2="624" stroke="#fff" stroke-width="0.5"/>
+    <line x1="0" y1="0" x2="0" y2="630" stroke="#fff" stroke-width="0.5"/>
+    <line x1="48" y1="0" x2="48" y2="630" stroke="#fff" stroke-width="0.5"/>
+    <line x1="96" y1="0" x2="96" y2="630" stroke="#fff" stroke-width="0.5"/>
+    <line x1="144" y1="0" x2="144" y2="630" stroke="#fff" stroke-width="0.5"/>
+    <line x1="192" y1="0" x2="192" y2="630" stroke="#fff" stroke-width="0.5"/>
+    <line x1="240" y1="0" x2="240" y2="630" stroke="#fff" stroke-width="0.5"/>
+    <line x1="288" y1="0" x2="288" y2="630" stroke="#fff" stroke-width="0.5"/>
+    <line x1="336" y1="0" x2="336" y2="630" stroke="#fff" stroke-width="0.5"/>
+    <line x1="384" y1="0" x2="384" y2="630" stroke="#fff" stroke-width="0.5"/>
+    <line x1="432" y1="0" x2="432" y2="630" stroke="#fff" stroke-width="0.5"/>
+    <line x1="480" y1="0" x2="480" y2="630" stroke="#fff" stroke-width="0.5"/>
+    <line x1="528" y1="0" x2="528" y2="630" stroke="#fff" stroke-width="0.5"/>
+    <line x1="576" y1="0" x2="576" y2="630" stroke="#fff" stroke-width="0.5"/>
+    <line x1="624" y1="0" x2="624" y2="630" stroke="#fff" stroke-width="0.5"/>
+    <line x1="672" y1="0" x2="672" y2="630" stroke="#fff" stroke-width="0.5"/>
+    <line x1="720" y1="0" x2="720" y2="630" stroke="#fff" stroke-width="0.5"/>
+    <line x1="768" y1="0" x2="768" y2="630" stroke="#fff" stroke-width="0.5"/>
+    <line x1="816" y1="0" x2="816" y2="630" stroke="#fff" stroke-width="0.5"/>
+    <line x1="864" y1="0" x2="864" y2="630" stroke="#fff" stroke-width="0.5"/>
+    <line x1="912" y1="0" x2="912" y2="630" stroke="#fff" stroke-width="0.5"/>
+    <line x1="960" y1="0" x2="960" y2="630" stroke="#fff" stroke-width="0.5"/>
+    <line x1="1008" y1="0" x2="1008" y2="630" stroke="#fff" stroke-width="0.5"/>
+    <line x1="1056" y1="0" x2="1056" y2="630" stroke="#fff" stroke-width="0.5"/>
+    <line x1="1104" y1="0" x2="1104" y2="630" stroke="#fff" stroke-width="0.5"/>
+    <line x1="1152" y1="0" x2="1152" y2="630" stroke="#fff" stroke-width="0.5"/>
+  </g>
+
+  <!-- Glow -->
+  <circle cx="600" cy="315" r="280" fill="#00FF41" opacity="0.06" filter="url(#blur)"/>
+
+  <!-- Logo mark -->
+  <g transform="translate(72, 72)">
+    <path d="M16 48 C 16 16 28 16 40 24 C 52 32 56 8 72 8 C 88 8 84 56 56 56 C 28 56 32 80 32 80" fill="none" stroke="#00FF41" stroke-width="3" stroke-linecap="round"/>
+    <path d="M28 48 C 28 30 34 30 46 34 C 58 38 62 22 70 22 C 80 22 76 44 60 44 C 44 44 48 60 48 60" fill="#00FF41" opacity="0.6"/>
+  </g>
+
+  <!-- Title -->
+  <text x="72" y="170" font-family="system-ui, -apple-system, sans-serif" font-size="52" font-weight="800" fill="#ffffff" letter-spacing="-1">
+    Professional design systems
+  </text>
+  <text x="72" y="236" font-family="system-ui, -apple-system, sans-serif" font-size="52" font-weight="800" fill="url(#accent)" letter-spacing="-1">
+    for your AI agent
+  </text>
+
+  <!-- Subtitle -->
+  <text x="72" y="300" font-family="system-ui, -apple-system, sans-serif" font-size="22" fill="#888888">
+    60+ production-grade design systems as one URL. No Figma. No manual tokens.
+  </text>
+
+  <!-- Color swatches row -->
+  <g transform="translate(72, 360)">
+    <rect x="0" y="0" width="80" height="80" rx="12" fill="#00FF41"/>
+    <rect x="96" y="0" width="80" height="80" rx="12" fill="#6366f1"/>
+    <rect x="192" y="0" width="80" height="80" rx="12" fill="#f59e0b"/>
+    <rect x="288" y="0" width="80" height="80" rx="12" fill="#ef4444"/>
+    <rect x="384" y="0" width="80" height="80" rx="12" fill="#06b6d4"/>
+    <rect x="480" y="0" width="80" height="80" rx="12" fill="#a855f7"/>
+    <rect x="576" y="0" width="80" height="80" rx="12" fill="#10b981"/>
+    <rect x="672" y="0" width="80" height="80" rx="12" fill="#f43f5e"/>
+    <rect x="768" y="0" width="80" height="80" rx="12" fill="#3b82f6"/>
+    <rect x="864" y="0" width="80" height="80" rx="12" fill="#78716c"/>
+  </g>
+
+  <!-- URL badge -->
+  <rect x="72" y="480" width="260" height="40" rx="20" fill="#ffffff" opacity="0.08"/>
+  <text x="202" y="506" font-family="system-ui, -apple-system, sans-serif" font-size="16" fill="#888888" text-anchor="middle">
+    luongnv.com/sleek-ui
+  </text>
+</svg>


### PR DESCRIPTION
Closes #80

## Summary

Add comprehensive Open Graph and Twitter Card meta tags to enable rich link previews when sharing the site on X/Twitter, HN, Reddit, Discord, Slack, and other platforms. Also includes a purpose-designed 1200×630 share image.

## Approach

- Added all standard OG and Twitter meta tags to `index.html`
- Created a share image (`public/sleek-ui-og.svg`) with branding, value prop text, and color swatch grid at 1200×630
- Tags include: description, og:title, og:description, og:image (1200×630), og:url, og:type, twitter:card (summary_large_image), twitter:title, twitter:description, twitter:image

## Changes

| File | Change |
|------|--------|
| `index.html` | Added 11 meta tags for OG and Twitter Card |
| `public/sleek-ui-og.svg` | New 1200×630 share preview image |

## Test Results

```
✓ Build: vite build succeeded (1.45s)
✓ Tests: 3 suites passed, 17 tests passed
✓ Meta tags verified present in dist/index.html
```

## Acceptance Criteria Verification

| # | Criterion | Status |
|---|-----------|--------|
| 1 | Meta description tag present in page head | ✓ |
| 2 | og:title, og:description, og:image (1200×630) present | ✓ |
| 3 | twitter:card (summary_large_image) and twitter:image present | ✓ |
| 4 | Share image reads as punchy thumbnail with text + visuals | ✓ |
