### PR TITLE
refactor(hero): rewrite headline and reduce to single CTA (#81) (#84)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -108,11 +108,11 @@ function HomePageInner() {
 
           <div className="space-y-4">
             <h1 className="text-4xl font-extrabold tracking-tight sm:text-5xl lg:text-6xl">
-              Professional design systems{' '}
-              <span className="text-[#00FF41]">for your AI agent</span>
+              Give your AI agent{' '}
+              <span className="text-[#00FF41]">good taste</span>
             </h1>
             <p className="mx-auto max-w-2xl text-lg text-muted-foreground sm:text-xl">
-              You ship features fast. Now ship the polish too. <strong className="text-foreground">{designs.length}+ production-grade design systems</strong> as one URL. No Figma. No manual tokens.
+              <strong className="text-foreground">{designs.length}+ production-grade design systems</strong>, one URL, zero Figma.
             </p>
           </div>
 
@@ -128,7 +128,7 @@ function HomePageInner() {
             ))}
           </div>
 
-          <div className="flex flex-col sm:flex-row gap-3 justify-center pt-2">
+          <div className="flex flex-col items-center gap-2 pt-2">
             <button
               onClick={() => document.getElementById('catalog')?.scrollIntoView({ behavior: 'smooth' })}
               className="inline-flex items-center justify-center rounded-md bg-[#00FF41] px-6 py-3 text-sm font-semibold text-black shadow hover:bg-[#00e639] active:bg-[#00cc33] transition-colors"
@@ -137,9 +137,9 @@ function HomePageInner() {
             </button>
             <button
               onClick={() => document.getElementById('how-it-works')?.scrollIntoView({ behavior: 'smooth' })}
-              className="inline-flex items-center justify-center rounded-md border border-border px-6 py-3 text-sm font-medium hover:bg-muted active:bg-muted/70 transition-colors"
+              className="text-sm text-muted-foreground hover:text-foreground transition-colors"
             >
-              See the plan
+              See how it works ↓
             </button>
           </div>
 

--- a/src/components/__tests__/HeroSection.test.tsx
+++ b/src/components/__tests__/HeroSection.test.tsx
@@ -1,0 +1,70 @@
+jest.mock('@/data/designs', () => {
+  const designs = [
+    {
+      slug: 'test-design',
+      name: 'Test Design',
+      categories: ['test'],
+      colors: { primary: '245 90% 73%', secondary: '0 0% 100%' },
+      defaultMode: 'light',
+      jsonUrl: 'https://luongnv.com/sleek-ui/designs/test-design.json',
+      thumbnailUrl: 'https://luongnv.com/sleek-ui/previews/test-design-thumb.svg',
+      detailUrl: '/designs/test-design',
+      description: 'A test design system',
+    },
+  ];
+  return { __esModule: true, default: designs };
+});
+
+import { render, screen } from '@testing-library/react';
+import App from '@/App';
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  });
+  window.scrollTo = jest.fn();
+});
+
+describe('Hero section', () => {
+  it('renders the new headline "Give your AI agent good taste"', () => {
+    render(<App />);
+    const headline = screen.getByRole('heading', { level: 1 });
+    expect(headline).toHaveTextContent(/Give your AI agent good taste/);
+  });
+
+  it('renders the subheading with design count, one URL, zero Figma', () => {
+    render(<App />);
+    expect(screen.getByText(/one URL, zero Figma/)).toBeInTheDocument();
+    expect(screen.getByText(/production-grade design systems/)).toBeInTheDocument();
+  });
+
+  it('shows a primary CTA button with Browse label styled as solid button', () => {
+    render(<App />);
+    const button = screen.getByText(/Browse.*Designs/);
+    expect(button.tagName).toBe('BUTTON');
+    expect(button.className).toContain('bg-[');
+  });
+
+  it('renders the secondary action as a text link without border styling', () => {
+    render(<App />);
+    const link = screen.getByText(/See how it works ↓/);
+    expect(link.tagName).toBe('BUTTON');
+    expect(link.className).not.toContain('border');
+    expect(link.className).toContain('text-muted-foreground');
+  });
+
+  it('primary CTA label includes design count from mock', () => {
+    render(<App />);
+    expect(screen.getByText(/Browse 1 Designs/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #81
Closes #84

## Summary
Two hero-section changes: rewrite the headline for stronger memorability (Issue #84) and reduce the hero to a single primary CTA (Issue #81).

## Approach
- Replaced headline from "Professional design systems for your AI agent" to "Give your AI agent good taste" with updated subheading
- Demoted secondary "See the plan" button to a plain text link ("See how it works ↓") below the primary CTA row
- Primary CTA (Browse N Designs) remains unchanged in destination and visual weight

## Changes
| File | Change |
|------|--------|
| `src/App.tsx` | Updated headline copy, subheading, and CTA buttons |
| `src/components/__tests__/HeroSection.test.tsx` | New test file for hero section |

## Test Results
```
Test Suites: 4 passed, 4 total
Tests:       22 passed, 22 total
```

## Acceptance Criteria
### Issue #81 (CTA)
- [x] Single button-styled CTA in hero
- [x] Secondary action reachable as text link
- [x] Primary CTA destination and label unchanged

### Issue #84 (Headline)
- [x] Headline replaced with shorter, outcome-driven copy
- [x] Subheading conveys design count, one URL, zero Figma
- [x] Responsive classes unchanged, legible at all breakpoints