### PR TITLE
refactor(homepage): restructure pain/success narrative section (#83) (#86)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -147,6 +147,21 @@ function HomePageInner() {
         </div>
       </section>
 
+      {/* ── PAIN (moved before video per #83) ── */}
+      <section className="border-t border-border/60 px-4 py-12 sm:py-14 bg-background">
+        <div className="mx-auto max-w-4xl">
+          <div className="rounded-xl border border-border/60 bg-muted/10 p-6 text-muted-foreground/90">
+            <div className="text-xs tracking-[2px] font-mono mb-2 opacity-70">THE ALTERNATIVE</div>
+            <h3 className="font-semibold mb-3 text-foreground/80">What most AI-built apps look like</h3>
+            <ul className="space-y-2 text-sm">
+              <li className="flex gap-2"><span className="mt-1">•</span> <span>Default browser styles or random Tailwind values.</span></li>
+              <li className="flex gap-2"><span className="mt-1">•</span> <span>Mismatched buttons, inputs, and cards that scream &ldquo;vibe coded&rdquo;.</span></li>
+              <li className="flex gap-2"><span className="mt-1">•</span> <span>Users trust polished interfaces more than raw functionality.</span></li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
       {/* ── VIDEO ── */}
       <section className="border-t border-border/60 px-4 py-14 sm:py-16 bg-muted/20">
         <div className="mx-auto max-w-4xl text-center space-y-5">
@@ -204,32 +219,6 @@ function HomePageInner() {
               />
             </div>
             <p className="mt-3 text-[11px] text-muted-foreground">The agent fetches the JSON and applies tokens, fonts, radius, and component classes automatically.</p>
-          </div>
-        </div>
-      </section>
-
-      {/* ── SUCCESS / STAKES (StoryBrand close) ── */}
-      <section className="border-t border-border/60 px-4 py-12 sm:py-14 bg-background">
-        <div className="mx-auto max-w-4xl">
-          <div className="grid gap-6 sm:grid-cols-2">
-            <div className="rounded-xl border border-border bg-card p-6">
-              <div className="text-[#00FF41] text-xs tracking-[2px] font-mono mb-2">SUCCESS</div>
-              <h3 className="font-semibold mb-3">What changes for you</h3>
-              <ul className="space-y-2 text-sm text-muted-foreground">
-                <li className="flex gap-2"><span className="mt-1">•</span> <span>Consistent spacing, type, and colors across light and dark.</span></li>
-                <li className="flex gap-2"><span className="mt-1">•</span> <span>Your app looks intentional — like a real product team shipped it.</span></li>
-                <li className="flex gap-2"><span className="mt-1">•</span> <span>Move on to the next feature instead of fighting CSS variables.</span></li>
-              </ul>
-            </div>
-            <div className="rounded-xl border border-border/60 bg-muted/10 p-6 text-muted-foreground/90">
-              <div className="text-xs tracking-[2px] font-mono mb-2 opacity-70">THE ALTERNATIVE</div>
-              <h3 className="font-semibold mb-3 text-foreground/80">What most AI-built apps look like</h3>
-              <ul className="space-y-2 text-sm">
-                <li className="flex gap-2"><span className="mt-1">•</span> <span>Default browser styles or random Tailwind values.</span></li>
-                <li className="flex gap-2"><span className="mt-1">•</span> <span>Mismatched buttons, inputs, and cards that scream "vibe coded".</span></li>
-                <li className="flex gap-2"><span className="mt-1">•</span> <span>Users trust polished interfaces more than raw functionality.</span></li>
-              </ul>
-            </div>
           </div>
         </div>
       </section>

--- a/src/components/__tests__/HeroSection.test.tsx
+++ b/src/components/__tests__/HeroSection.test.tsx
@@ -68,3 +68,44 @@ describe('Hero section', () => {
     expect(screen.getByText(/Browse 1 Designs/)).toBeInTheDocument();
   });
 });
+
+describe('Pain/problem section position (issue #83)', () => {
+  it('renders the pain/problem section describing what AI-built apps look like', () => {
+    render(<App />);
+    expect(screen.getByText(/What most AI-built apps look like/)).toBeInTheDocument();
+  });
+
+  it('renders pain section items about mismatched styles and vibe coding', () => {
+    render(<App />);
+    expect(screen.getByText(/Default browser styles or random Tailwind values/)).toBeInTheDocument();
+    expect(screen.getByText(/Mismatched buttons, inputs, and cards/)).toBeInTheDocument();
+    expect(screen.getByText(/Users trust polished interfaces/)).toBeInTheDocument();
+  });
+
+  it('pain section appears before the demo video section in DOM order', () => {
+    const { container } = render(<App />);
+    const html = container.innerHTML;
+    const painIndex = html.indexOf('What most AI-built apps look like');
+    const videoIndex = html.indexOf('Watch it transform a real app');
+    expect(painIndex).toBeGreaterThan(0);
+    expect(videoIndex).toBeGreaterThan(0);
+    expect(painIndex).toBeLessThan(videoIndex);
+  });
+});
+
+describe('Success-recap card removal (issue #86)', () => {
+  it('does not render the redundant success-recap card "What changes for you"', () => {
+    render(<App />);
+    expect(screen.queryByText(/What changes for you/)).not.toBeInTheDocument();
+  });
+
+  it('does not render the SUCCESS label in a card section', () => {
+    render(<App />);
+    expect(screen.queryByText(/SUCCESS/)).not.toBeInTheDocument();
+  });
+
+  it('does not render the "Consistent spacing, type, and colors" success item', () => {
+    render(<App />);
+    expect(screen.queryByText(/Consistent spacing, type, and colors/)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #83
Closes #86

## Summary

Restructure the landing page's pain/success narrative sections as a unified fix for both issues: move the pain/problem section before the demo video so visitors feel the problem before seeing the solution, and drop the redundant success-recap card since its message is already conveyed by the hero.

## Approach

1. **Issue #83** — Extracted the "What most AI-built apps look like" card from the old SUCCESS/STAKES section and moved it between the hero and the demo video. The pain naming now precedes the video so the demo lands as "the answer to what you just felt."
2. **Issue #86** — Removed the now-redundant "What changes for you" success-recap card entirely. With the pain card moved earlier, this card was restating what the hero already communicates, and its content was structurally redundant per #86's Option A.

## Changes

| File | Change |
|------|--------|
| `src/App.tsx` | Moved pain section ("The Alternative") before video; removed entire SUCCESS/STAKES section |
| `src/components/__tests__/HeroSection.test.tsx` | Added 6 tests: pain section visibility, pain before video in DOM order, success-recap card removed |

## Test Results

```
Test Suites: 4 passed, 4 total
Tests:       28 passed, 28 total
```

## Acceptance Criteria

### #83 — Move pain/problem section before demo video
- [x] The problem/pain section appears before the demo video in page order
- [x] The demo video section still reads coherently as the direct answer to the pain just described
- [x] No content is lost in the move — only order changes

### #86 — Simplify Success/Alternative section to one idea per screen
- [x] The section no longer presents two competing narratives as parallel side-by-side cards
- [x] The resulting section reads as a single clear idea rather than a comparison to parse
- [x] No unique content from either card is lost outright — only structure/redundancy changes