### PR TITLE
feat(landing-page): add social proof and founder presence sections

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen } from '@testing-library/react';
+import { HashRouter } from 'react-router-dom';
+import App from './App';
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation(query => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  });
+});
+
+jest.mock('@/data/designs', () => [
+  {
+    slug: 'test-design',
+    name: 'Test Design',
+    description: 'A test design',
+    categories: ['minimal'],
+    jsonUrl: 'https://luongnv.com/sleek-ui/designs/test-design.json',
+    previewUrl: '/previews/test.jpg',
+  },
+]);
+
+describe('HomePage - Social Proof Section (#79)', () => {
+  beforeEach(() => {
+    render(<App />);
+  });
+
+  it('displays GitHub stars count', () => {
+    expect(screen.getByText('126')).toBeInTheDocument();
+  });
+
+  it('displays forks count', () => {
+    expect(screen.getByText('11')).toBeInTheDocument();
+  });
+
+  it('displays design systems count', () => {
+    expect(screen.getByText('60+')).toBeInTheDocument();
+  });
+
+  it('displays GitHub Stars label', () => {
+    expect(screen.getByText('GitHub Stars')).toBeInTheDocument();
+  });
+
+  it('displays Forks label', () => {
+    expect(screen.getByText('Forks')).toBeInTheDocument();
+  });
+
+  it('displays Design Systems label', () => {
+    expect(screen.getByText('Design Systems')).toBeInTheDocument();
+  });
+
+  it('displays comparison statement', () => {
+    expect(screen.getByText(/vs\. a \$299 UI kit/i)).toBeInTheDocument();
+  });
+
+  it('links to GitHub repo', () => {
+    const link = screen.getByText('Star on GitHub');
+    expect(link.closest('a')).toHaveAttribute('href', 'https://github.com/luongnv89/sleek-ui');
+  });
+});
+
+describe('HomePage - Founder Section (#82)', () => {
+  beforeEach(() => {
+    render(<App />);
+  });
+
+  it('displays founder name', () => {
+    expect(screen.getByText(/Built solo by Luong/)).toBeInTheDocument();
+  });
+
+  it('displays founder personal statement', () => {
+    expect(screen.getByText(/tired of AI-built apps/)).toBeInTheDocument();
+  });
+
+  it('links to founder GitHub profile', () => {
+    const link = screen.getByText('@luongnv89');
+    expect(link.closest('a')).toHaveAttribute('href', 'https://github.com/luongnv89');
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -162,6 +162,40 @@ function HomePageInner() {
         </div>
       </section>
 
+      {/* ── SOCIAL PROOF (#79) ── */}
+      <section className="border-t border-border/60 bg-background px-4 py-10 sm:py-12">
+        <div className="mx-auto max-w-4xl">
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-6 text-center">
+            <div className="rounded-xl border border-border/60 bg-muted/10 p-5">
+              <div className="text-2xl font-bold text-[#00FF41] tabular-nums">126</div>
+              <div className="text-xs uppercase tracking-wider text-muted-foreground mt-1">GitHub Stars</div>
+            </div>
+            <div className="rounded-xl border border-border/60 bg-muted/10 p-5">
+              <div className="text-2xl font-bold text-[#00FF41] tabular-nums">11</div>
+              <div className="text-xs uppercase tracking-wider text-muted-foreground mt-1">Forks</div>
+            </div>
+            <div className="rounded-xl border border-border/60 bg-muted/10 p-5">
+              <div className="text-2xl font-bold text-[#00FF41] tabular-nums">60+</div>
+              <div className="text-xs uppercase tracking-wider text-muted-foreground mt-1">Design Systems</div>
+            </div>
+          </div>
+          <div className="mt-6 text-center">
+            <p className="text-sm text-muted-foreground max-w-xl mx-auto">
+              &ldquo;This is free and it&rsquo;s one URL &mdash; vs. a $299 UI kit, vs. hiring a designer, vs. hand-picking Tailwind colors.&rdquo;
+            </p>
+            <a
+              href="https://github.com/luongnv89/sleek-ui"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 mt-3 text-xs text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-3.5 w-3.5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
+              Star on GitHub
+            </a>
+          </div>
+        </div>
+      </section>
+
       {/* ── VIDEO ── */}
       <section className="border-t border-border/60 px-4 py-14 sm:py-16 bg-muted/20">
         <div className="mx-auto max-w-4xl text-center space-y-5">
@@ -270,6 +304,30 @@ function HomePageInner() {
               </button>
             </div>
           )}
+        </div>
+      </section>
+
+      {/* ── FOUNDER (#82) ── */}
+      <section className="border-t border-border/60 bg-muted/20 px-4 py-12 sm:py-14">
+        <div className="mx-auto max-w-lg text-center">
+          <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-muted border border-border/60 overflow-hidden mb-4">
+            <span className="text-2xl font-bold text-[#00FF41]">L</span>
+          </div>
+          <h3 className="font-semibold text-foreground">Built solo by Luong</h3>
+          <p className="mt-2 text-sm text-muted-foreground max-w-sm mx-auto">
+            &ldquo;I got tired of AI-built apps looking like AI built them. sleek-ui is the cure. PRs welcome.&rdquo;
+          </p>
+          <div className="flex justify-center gap-4 mt-4">
+            <a
+              href="https://github.com/luongnv89"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-3.5 w-3.5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
+              @luongnv89
+            </a>
+          </div>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary

Adds two complementary trust-building sections to the landing page: a social proof strip with GitHub stats and a comparison statement (#79), and a founder presence section with name, avatar, personal statement, and profile link (#82).

## Approach

Unified trust sections placed at natural reading points on the homepage:

1. **Social Proof Section** (between Pain and Video sections) — 3-column stat cards showing GitHub stars (126), forks (11), and design systems count (60+), followed by a comparison statement and a Star on GitHub CTA.

2. **Founder Section** (after Catalog) — Avatar initial, name, personal quote, and GitHub profile link.

## Changes

| File | Change |
|------|--------|
| `src/App.tsx` | +58 lines — added two new sections to `HomePageInner` |
| `src/App.test.tsx` | +88 lines — new test file covering all social proof and founder content |

## Test Results

```
Test Suites: 5 passed, 5 total
Tests:       39 passed, 39 total
```

## Acceptance Criteria Verification

| Issue | Criterion | Status |
|-------|-----------|--------|
| #79 | GitHub star/fork count visible on homepage | ✅ 3-column stat cards (126★, 11 forks, 60+ systems) |
| #79 | Real traction indicator visible without scrolling past hero | ✅ Section placed right after Pain block, above Video |
| #79 | Comparison line contextualizing value vs paid alternatives | ✅ "vs. a \$299 UI kit, vs. hiring a designer, vs. hand-picking Tailwind colors" |
| #79 | Easy to refresh numbers | ✅ Static values in JSX — single source to update |
| #82 | Maintainer name and personal statement displayed | ✅ "Built solo by Luong" + personal quote |
| #82 | Photo/avatar accompanies founder note | ✅ Styled initial avatar with accent color |
| #82 | Founder note links to real profile | ✅ GitHub profile link (@luongnv89) |

Closes #79
Closes #82