### PR TITLE
refactor(footer): rewrite closing line to be more shareable (#85)

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -63,8 +63,42 @@ describe('HomePage - Social Proof Section (#79)', () => {
   });
 
   it('links to GitHub repo', () => {
-    const link = screen.getByText('Star on GitHub');
-    expect(link.closest('a')).toHaveAttribute('href', 'https://github.com/luongnv89/sleek-ui');
+    const links = screen.getAllByText('Star on GitHub');
+    links.forEach(link => {
+      expect(link.closest('a')).toHaveAttribute('href', 'https://github.com/luongnv89/sleek-ui');
+    });
+  });
+});
+
+describe('Footer - Shareable Closing Line (#85)', () => {
+  beforeEach(() => {
+    render(<App />);
+  });
+
+  it('displays the bold quotable closing line', () => {
+    expect(screen.getByText(/Your app shouldn.*t look like it was built in a weekend/i)).toBeInTheDocument();
+  });
+
+  it('displays Star on GitHub CTA in the footer', () => {
+    const footer = document.querySelector('footer');
+    expect(footer).toBeInTheDocument();
+    const starLink = footer!.querySelector('a[href="https://github.com/luongnv89/sleek-ui"]');
+    expect(starLink).toBeInTheDocument();
+    expect(starLink!.textContent).toMatch(/Star on GitHub/);
+  });
+
+  it('preserves navigation links', () => {
+    const footer = document.querySelector('footer');
+    expect(footer).toBeInTheDocument();
+    expect(footer!.textContent).toMatch(/Catalog/);
+    expect(footer!.textContent).toMatch(/How it works/);
+    expect(footer!.textContent).toMatch(/Brand/);
+  });
+
+  it('displays the open source tagline', () => {
+    const footer = document.querySelector('footer');
+    expect(footer).toBeInTheDocument();
+    expect(footer!.textContent).toMatch(/Free.*Open source.*60.*designs/);
   });
 });
 

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -8,16 +8,29 @@ export function Layout() {
       <main className="flex-1">
         <Outlet />
       </main>
-      <footer className="border-t bg-background py-8">
-        <div className="container mx-auto px-4 text-center text-muted-foreground">
-          <p className="text-sm">sleek-ui — design systems that AI agents can actually use.</p>
-          <div className="flex flex-wrap justify-center gap-x-5 gap-y-1 mt-4 text-sm">
+      <footer className="border-t bg-background py-10">
+        <div className="container mx-auto px-4 text-center">
+          <p className="text-lg font-semibold text-foreground max-w-lg mx-auto leading-relaxed">
+            &ldquo;Your app shouldn&rsquo;t look like it was built in a weekend. <span className="text-muted-foreground">(Even if it was.)</span>&rdquo;
+          </p>
+          <div className="mt-5">
+            <a
+              href="https://github.com/luongnv89/sleek-ui"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 rounded-md bg-[#00FF41] px-4 py-2 text-sm font-semibold text-black hover:bg-[#00e639] transition-colors"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
+              Star on GitHub
+            </a>
+          </div>
+          <nav className="flex flex-wrap justify-center gap-x-5 gap-y-1 mt-6 text-sm text-muted-foreground">
             <Link to="/" className="hover:text-foreground transition-colors">Catalog</Link>
             <a href="#how-it-works" className="hover:text-foreground transition-colors">How it works</a>
             <a href="https://github.com/luongnv89/sleek-ui" className="hover:text-foreground transition-colors" target="_blank" rel="noopener noreferrer">GitHub</a>
             <a href="/sleek-ui/logo/brand-showcase.html" className="hover:text-foreground transition-colors">Brand</a>
-          </div>
-          <p className="mt-4 text-[10px] opacity-60">Free • Open source • 60+ designs</p>
+          </nav>
+          <p className="mt-6 text-[10px] opacity-60 text-muted-foreground">Free • Open source • 60+ designs</p>
         </div>
       </footer>
     </div>


### PR DESCRIPTION
Closes #85

## Summary

Rewrite the footer closing line from a plain tagline to a bold, quotable statement with a prominent "Star on GitHub" call-to-action.

## Approach

Balanced approach — lead with a memorable closing line, add a visual CTA button, and keep the existing navigation links and tagline.

## Decision Record

- **Root cause:** The footer closed with a flat tagline and link list, missing the opportunity to end on something quotable and shareable.
- **Options considered:** Option 1 — Minimal: swap text only; Option 2 — Balanced: bold quote + CTA button + preserved links (selected); Option 3 — Comprehensive: full footer redesign with background/icon treatment.
- **Options rejected:** Option 1 — too minimal, doesn't give CTA enough visual weight; Option 3 — over-engineered for a copy-focused change.
- **Selected option:** Option 2 — Balanced approach
- **Residual risk:** none identified

Analyzed at: `refactor/85-rewrite-footer-closing-line @ ccbe4bc` (2026-07-05)

## Changes

| File | Change |
|------|--------|
| `src/components/layout/Layout.tsx` | Replace plain tagline with bold quotable line, add "Star on GitHub" CTA button, wrap links in `<nav>` |
| `src/App.test.tsx` | Update existing "Star on GitHub" test for multiple matches; add 4 footer-specific tests |

## Test Results

- Unit tests: 43 passed
- Integration tests: skipped
- E2e tests: skipped
- Build: passed
- QA cycles: 1

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Footer leads with a short, bold, quotable line | pass | `src/components/layout/Layout.tsx:13-15` — displayed and tested |
| A single clear "Star on GitHub" CTA is present | pass | `src/components/layout/Layout.tsx:17-25` — green button with GitHub icon |
| Existing footer navigation links remain reachable | pass | `src/components/layout/Layout.tsx:27-32` — Catalog, How it works, GitHub, Brand preserved