### PR TITLE
fix(nav): replace in-page hash anchors with scrollIntoView buttons (#104)

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { HashRouter } from 'react-router-dom';
 import App from './App';
 
@@ -118,5 +119,50 @@ describe('HomePage - Founder Section (#82)', () => {
   it('links to founder GitHub profile', () => {
     const link = screen.getByText('@luongnv89');
     expect(link.closest('a')).toHaveAttribute('href', 'https://github.com/luongnv89');
+  });
+});
+
+describe('In-page anchor controls under HashRouter (#104)', () => {
+  let scrollIntoView: jest.Mock;
+
+  beforeEach(() => {
+    scrollIntoView = jest.fn();
+    Element.prototype.scrollIntoView = scrollIntoView;
+    window.location.hash = '#/';
+    render(<App />);
+  });
+
+  afterEach(() => {
+    delete (Element.prototype as Partial<Element>).scrollIntoView;
+  });
+
+  const expectRouteKeptAndScrolled = () => {
+    expect(window.location.hash).toBe('#/');
+    expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' });
+  };
+
+  it('header desktop How it works scrolls without breaking the route', async () => {
+    await userEvent.click(screen.getAllByRole('button', { name: 'How it works' })[0]);
+    expectRouteKeptAndScrolled();
+  });
+
+  it('footer How it works scrolls without breaking the route', async () => {
+    const footer = document.querySelector('footer')!;
+    await userEvent.click(
+      within(footer).getByRole('button', { name: 'How it works' })
+    );
+    expectRouteKeptAndScrolled();
+  });
+
+  it('mobile menu Browse Designs scrolls to catalog and closes the menu', async () => {
+    await userEvent.click(screen.getByRole('button', { name: /Open menu/i }));
+    await userEvent.click(screen.getByRole('button', { name: 'Browse Designs' }));
+    expectRouteKeptAndScrolled();
+    expect(screen.queryByRole('button', { name: /Close menu/i })).not.toBeInTheDocument();
+  });
+
+  it('renders no hash-anchor hrefs for in-page sections', () => {
+    expect(document.querySelector('a[href="#how-it-works"]')).toBeNull();
+    expect(document.querySelector('a[href="#catalog"]')).toBeNull();
   });
 });

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -26,7 +26,7 @@ export function Layout() {
           </div>
           <nav className="flex flex-wrap justify-center gap-x-5 gap-y-1 mt-6 text-sm text-muted-foreground">
             <Link to="/" className="hover:text-foreground transition-colors">Catalog</Link>
-            <a href="#how-it-works" className="hover:text-foreground transition-colors">How it works</a>
+            <button onClick={() => document.getElementById('how-it-works')?.scrollIntoView({ behavior: 'smooth' })} className="hover:text-foreground transition-colors">How it works</button>
             <a href="https://github.com/luongnv89/sleek-ui" className="hover:text-foreground transition-colors" target="_blank" rel="noopener noreferrer">GitHub</a>
             <a href="/sleek-ui/logo/brand-showcase.html" className="hover:text-foreground transition-colors">Brand</a>
           </nav>

--- a/src/components/ui/header.tsx
+++ b/src/components/ui/header.tsx
@@ -30,9 +30,12 @@ export function Header() {
           <Link to="/" className={navLinkClass}>
             Catalog
           </Link>
-          <a href="#how-it-works" className={navLinkMutedClass}>
+          <button
+            onClick={() => document.getElementById('how-it-works')?.scrollIntoView({ behavior: 'smooth' })}
+            className={navLinkMutedClass}
+          >
             How it works
-          </a>
+          </button>
           <a href="https://github.com/luongnv89/sleek-ui" target="_blank" rel="noopener noreferrer" className={navLinkMutedClass}>
             GitHub
           </a>
@@ -65,13 +68,15 @@ export function Header() {
             >
               Catalog
             </Link>
-            <a
-              href="#how-it-works"
-              className="block py-2.5 text-sm font-medium text-muted-foreground hover:text-foreground"
-              onClick={closeMenu}
+            <button
+              className="block py-2.5 text-left text-sm font-medium text-muted-foreground hover:text-foreground"
+              onClick={() => {
+                document.getElementById('how-it-works')?.scrollIntoView({ behavior: 'smooth' })
+                closeMenu()
+              }}
             >
               How it works
-            </a>
+            </button>
             <a
               href="https://github.com/luongnv89/sleek-ui"
               target="_blank"
@@ -82,13 +87,15 @@ export function Header() {
               GitHub
             </a>
             <div className="pt-2 mt-1 border-t">
-              <a
-                href="#catalog"
+              <button
                 className="inline-flex w-full items-center justify-center rounded-md bg-[#00FF41] px-4 py-2 text-sm font-semibold text-black hover:bg-[#00e639] transition-colors"
-                onClick={closeMenu}
+                onClick={() => {
+                  document.getElementById('catalog')?.scrollIntoView({ behavior: 'smooth' })
+                  closeMenu()
+                }}
               >
                 Browse Designs
-              </a>
+              </button>
             </div>
           </nav>
         </div>


### PR DESCRIPTION
## Summary

Header and footer used `href="#how-it-works"` / `href="#catalog"` anchors, which HashRouter rewrites into unmatched routes — blanking the main content area until the user pressed Back. All in-page anchor controls are now buttons that call `scrollIntoView({ behavior: 'smooth' })` on the target section, matching the existing hero-CTA pattern in `App.tsx`.

Closes #104

## Approach

Replace each hash-anchor control with a `<button>` invoking the same scroll helper already used by the hero CTAs (`document.getElementById(...)?.scrollIntoView(...)`), keeping identical visual styling. BrowserRouter migration is out of scope (deferred to Task 3.3).

**Decision Record**
- **Selected option:** Direct minimal fix (light profile) — convert anchors to scrollIntoView buttons
- **Rejected:** (a) Migrating HashRouter → BrowserRouter (large blast radius, deferred by plan); (b) intercepting clicks on anchors via preventDefault (keeps misleading semantics, still renders as links)
- **Risk rating:** Low — 3 UI files + tests; no routing or data changes

## Changes

| File | Change |
|------|--------|
| `src/components/ui/header.tsx` | Desktop nav, mobile nav, and mobile CTA anchors → buttons calling scrollIntoView |
| `src/components/layout/Layout.tsx` | Footer "How it works" anchor → scrollIntoView button |
| `src/App.test.tsx` | Regression suite: route stays matched + scrollIntoView invoked for each control |

## Test Results

- `npm test`: 7 suites / **63 passed**, 0 failed (4 new regression tests)
- `npm run build`: ✓ built successfully
- `npm run validate:designs`: ✓ all designs valid

## Acceptance Criteria Verification

| Criterion | Status |
|-----------|--------|
| Clicking each header/footer anchor control keeps the route matched and invokes scrollIntoView on the target section | ✅ Covered by new tests: desktop "How it works", footer "How it works", mobile "Browse Designs" — each asserts `window.location.hash === '#/'` after click and `scrollIntoView` called with `{ behavior: 'smooth' }`; plus a guard that no `#how-it-works`/`#catalog` hrefs remain |
| `npm test` passes at ≥ baseline pass rate | ✅ 63/63 pass (baseline-green holds) |