### PR TITLE
chore(deps): upgrade lucide-react to ^1.33.0 (#109)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "lucide-react": "^0.441.0",
+        "lucide-react": "^1.33.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.30.3",
@@ -42,6 +42,9 @@
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.67.0",
         "vite": "^5.4.21"
+      },
+      "engines": {
+        "node": ">=22 <23"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -7827,12 +7830,12 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.441.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.441.0.tgz",
-      "integrity": "sha512-0vfExYtvSDhkC2lqg0zYVW1Uu9GsI4knuV9GP9by5z0Xhc4Zi5RejTxfz9LsjRmCyWVzHCJvxGKZWcRyvQCWVg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.33.0.tgz",
+      "integrity": "sha512-MTRwMy0ZlL8Ur/vOAiJ9XGHE+kFPC7brq6MxAm0GiGXEBj0qy0jA/pG4N675oSzciO/UCdX8T+5yUQdmDeTLxg==",
       "license": "ISC",
       "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lz-string": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "lucide-react": "^0.441.0",
+    "lucide-react": "^1.33.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.30.3",


### PR DESCRIPTION
Closes #109

## Summary

Major upgrade of `lucide-react` from 0.441.0 to ^1.33.0 (latest v1). The upgrade required zero source changes — all 11 icons imported across `src/` remain exported in v1.

## Spike Note (breaking changes 0.441 → 1.x affecting this repo)

Per the issue's spike requirement, grepped every `lucide-react` import in the repo and checked each against the [v0→v1 migration guide](https://lucide.dev/guide/react/migration):

| v1 breaking change | Affects this repo? |
|---|---|
| Brand icons removed (`Github`, `Facebook`, `Figma`, `Slack`, …) | **No** — none imported |
| Icon renames / deletions | **No** — all 11 imports verified exported in 1.33.0: `ArrowLeft`, `Check`, `Copy`, `Moon`, `Sun`, `Paintbrush`, `RotateCcw`, `X`, `Menu`, `Search`, `AlertCircle` |
| UMD build dropped (ESM/CJS only) | **No** — Vite consumes ESM |
| `aria-hidden` now defaults to `true` | Benign improvement — all icon usages here are decorative |
| New `LucideProvider` context API | Optional, not adopted |

## Approach

Dependency-only change: bump `package.json` to `^1.33.0`, regenerate lockfile via `npm install`. Verified all runtime icon exports via node resolution against the installed package before committing.

## Decision Record

**Selected option:** Minimal — direct dependency bump with export verification (light profile; Effort band S). Alternatives considered: adopting `LucideProvider` for shared icon defaults (deferred — no current duplication of props worth abstracting); pinning exact version instead of caret (kept caret per issue's "^1.x installed" criterion).

## Changes

| File | Change |
|------|--------|
| `package.json` | `lucide-react`: `^0.441.0` → `^1.33.0` |
| `package-lock.json` | Regenerated for 1.33.0 |

## Test Results

- `npm run build` ✓ (vite build succeeds)
- `npm run typecheck` ✓ (`tsc --noEmit` clean)
- `npm test` ✓ 8 suites, 69/69 tests pass
- `npm ls lucide-react` → `lucide-react@1.33.0`

## Acceptance Criteria Verification

| Criterion | Status |
|---|---|
| Spike note recorded listing every breaking icon change affecting this repo's imports | ✅ Recorded above |
| `npm ls lucide-react` shows ^1.x; build and typecheck succeed with zero unresolved icon imports | ✅ 1.33.0; both green |
| Tests pass at ≥ baseline-green rate | ✅ 69/69 pass |