### PR TITLE
chore(deps): upgrade react-router-dom to ^7 (#111)

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -89,5 +89,5 @@ npm run build && npm run preview
 | TypeScript | 5 | Type safety |
 | Tailwind CSS | 3.4 | Utility-first styling |
 | shadcn/ui | latest | Accessible UI primitives |
-| react-router-dom | 6 | Client-side routing (HashRouter) |
+| react-router-dom | 7 | Client-side routing (HashRouter — see [ROUTER_DECISION.md](ROUTER_DECISION.md)) |
 | lucide-react | 0.441 | Icon library |

--- a/docs/ROUTER_DECISION.md
+++ b/docs/ROUTER_DECISION.md
@@ -1,0 +1,42 @@
+# Router Decision: HashRouter kept on react-router-dom v7
+
+**Date:** 2026-08-22
+**Issue:** [#111](https://github.com/luongnv89/sleek-ui/issues/111) — Major upgrade react-router-dom 6 to ^7.x
+**Decision:** Keep `HashRouter`; do **not** migrate to `BrowserRouter` as part of the v7 upgrade.
+
+## Context
+
+sleek-ui is a single-page React app deployed via GitHub Pages at
+`https://luongnv.com/sleek-ui/`. GitHub Pages serves static files only and has
+no SPA rewrite rule: any path other than `/sleek-ui/` (or a real file) returns
+a plain `404 Not Found` instead of `index.html`.
+
+## Options considered
+
+| Option | Outcome |
+|--------|---------|
+| **Keep HashRouter** ✅ | All routes live under `/#/…`, so every deep link resolves to `/sleek-ui/index.html` and is served correctly. No server config needed. |
+| Migrate to BrowserRouter + 404.html trick | Possible (copy `index.html` → `404.html`, parse the real path client-side), but adds a hacky redirect layer and changes all URLs. |
+| Migrate to BrowserRouter alone | Breaks: deep links like `/sleek-ui/designs/foo` would 404 on GitHub Pages, breaking shared design links — the product's core flow. |
+
+## Consequences
+
+- The Task 1.5 / #104 `scrollIntoView` in-page-anchor workaround remains
+  necessary: with `HashRouter`, plain `#section` hrefs would collide with the
+  router's hash, so in-page navigation uses buttons calling
+  `scrollIntoView({ behavior: 'smooth' })`. This workaround would only become
+  obsolete if the app ever moves off GitHub Pages or adopts the 404.html
+  approach.
+- URLs remain of the form `/sleek-ui/#/designs/{slug}`.
+
+## Upgrade notes (v6 → v7)
+
+- Declarative mode (`<HashRouter>`, `<Routes>`, `<Route>`) is fully supported
+  in v7; no component changes were required.
+- `react-router-dom@7` re-exports from the unified `react-router` package;
+  existing imports continue to work unchanged.
+- Jest/jsdom needed an explicit `TextEncoder`/`TextDecoder` global polyfill
+  (added in `jest.setup.cjs`) because react-router v7 references them at module
+  load time.
+- Requires Node >= 20 and React >= 18 — both satisfied (React stays on 18
+  until #113).

--- a/jest.setup.cjs
+++ b/jest.setup.cjs
@@ -1,1 +1,10 @@
+const { TextEncoder, TextDecoder } = require('node:util');
+
+if (typeof globalThis.TextEncoder === 'undefined') {
+  globalThis.TextEncoder = TextEncoder;
+}
+if (typeof globalThis.TextDecoder === 'undefined') {
+  globalThis.TextDecoder = TextDecoder;
+}
+
 require('@testing-library/jest-dom');

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "lucide-react": "^1.33.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-router-dom": "^6.30.3",
+        "react-router-dom": "^7.18.2",
         "tailwind-merge": "^3.6.0"
       },
       "devDependencies": {
@@ -3422,15 +3422,6 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
-    "node_modules/@remix-run/router": {
-      "version": "1.23.4",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.4.tgz",
-      "integrity": "sha512-q7j5geK7xs3UJSdm9/iytUNclBnLmYx1EnSeCFXHPeutdqgIMeFeHtUZgS3EhlKxdBEAu8OwtJCwmLrEzpSs7Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -5562,6 +5553,19 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/core-js-compat": {
       "version": "3.49.0",
@@ -8673,35 +8677,41 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.6",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.6.tgz",
-      "integrity": "sha512-5HfK7k5im7LTOB0EqCQmfvy4C13G92Ssj1VTmouTK3AJvyjKTnFuCV0vcMAD/JS+JC4DvDIBRrlAeJIFjh5VWg==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.4"
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.6",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.6.tgz",
-      "integrity": "sha512-0RHKZz7wwffvkU+2MFVT2NnjK44ssLEV+m0CAJaS2Ksmorrwj7WxH00jO0SOCW26/tINUnJHToXblDs33I38YQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.4",
-        "react-router": "6.30.6"
+        "react-router": "7.18.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/read-cache": {
@@ -9002,6 +9012,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lucide-react": "^1.33.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.30.3",
+    "react-router-dom": "^7.18.2",
     "tailwind-merge": "^3.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Closes #111

## Summary

Upgrades `react-router-dom` from ^6.30.3 to ^7.x (7.18.2). The declarative routing API (`HashRouter`, `<Routes>`, `<Route>`, `Link`, `Outlet`, `useParams`, `useLocation`) is unchanged in v7, so no application components required modification. The only code change is a Jest/jsdom global polyfill (`TextEncoder`/`TextDecoder`) that react-router v7 references at module load time.

## Approach

- Applied the upstream React Router v6→v7 upgrade guide: bumped the package, verified Node (22) and React (18) prerequisites — react/react-dom remain on 18 until #113, which router v7 fully supports.
- Fixed test-environment compatibility by adding a guarded `TextEncoder`/`TextDecoder` polyfill in `jest.setup.cjs`.
- Recorded the HashRouter-vs-BrowserRouter decision in `docs/ROUTER_DECISION.md`.

## Decision Record

**HashRouter kept; not migrated to BrowserRouter.** sleek-ui deploys as a static SPA on GitHub Pages (`/sleek-ui/`) which has no SPA rewrite rule — deep links such as `/designs/{slug}` would return a plain 404 under BrowserRouter, breaking shared design links (the product's core flow). Consequences: URLs stay `/sleek-ui/#/designs/{slug}`, and the #104 `scrollIntoView` in-page-anchor workaround remains necessary. Migration options are documented in `docs/ROUTER_DECISION.md` should the hosting model ever change.

## Changes

| File | Change |
|------|--------|
| `package.json` | `react-router-dom`: `^6.30.3` → `^7.18.2` |
| `package-lock.json` | Lockfile regenerated for router v7 |
| `jest.setup.cjs` | Guarded jsdom polyfill for `TextEncoder`/`TextDecoder` |
| `docs/DEVELOPMENT.md` | Tech-stack version table updated to 7 + decision doc link |
| `docs/ROUTER_DECISION.md` | New: HashRouter decision record |

## Test Results

- Baseline before upgrade: **78/78 passing** (9 suites)
- After upgrade: **78/78 passing** (9 suites) — all routes render
- `npm run build` ✓ · `npm run typecheck` ✓ · `npm run lint` ✓
- `npm ls react-router-dom` → `react-router-dom@7.18.2`

## Acceptance Criteria Verification

| Criterion | Status |
|-----------|--------|
| Upgrade-guide steps applied; `npm ls react-router-dom` shows ^7.x; all routes render in tests | ✅ v7.18.2, declarative routes render across all 78 tests |
| Router decision (HashRouter kept vs migrated) recorded in docs or PR description | ✅ Both — `docs/ROUTER_DECISION.md` + Decision Record above |
| `npm test` passes at ≥ baseline-green rate | ✅ 78/78 = baseline 78/78 |