### PR TITLE
test(config): enable Jest coverage with thresholds (#116)

### DIFF
--- a/docs/AGENT_ENV.md
+++ b/docs/AGENT_ENV.md
@@ -29,7 +29,9 @@ npm run dev               # Vite dev server
 - Test locations: `src/**/*.test.{ts,tsx}` and `tests/**/*.test.js`.
 - Setup file: `jest.setup.cjs`.
 
-Pass rate at baseline: 69/69 (8 suites, all passing — recorded 2026-08-22 on Node 20 CI pin and local Node 26; see issue #97). This is the documented baseline-green floor: later tasks must keep `npm test` at or above it.
+Pass rate at baseline: 69/69 (8 suites, all passing — recorded 2026-08-22 on Node 20 CI pin and local Node 26; see issue #97). This is the documented baseline-green floor: later tasks must keep `npm test` at or above it. Current rate: 78/78 (9 suites, all passing).
+
+Coverage (`npx jest --coverage`, measured 2026-08-22, see issue #116): global statements 71.05%, branches 56.43%, functions 66.66%, lines 73.29%. `coverageThreshold` in `jest.config.cjs` guards a permissive floor below these numbers (statements 65 / branches 50 / functions 60 / lines 68); ratchet upward as the test campaign lands.
 
 ### Design validation
 

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,5 +1,16 @@
 module.exports = {
   testEnvironment: 'jsdom',
+  collectCoverage: true,
+  coverageDirectory: 'coverage',
+  coveragePathIgnorePatterns: ['/node_modules/', '/video/'],
+  coverageThreshold: {
+    global: {
+      statements: 65,
+      branches: 50,
+      functions: 60,
+      lines: 68,
+    },
+  },
   setupFilesAfterEnv: ['<rootDir>/jest.setup.cjs'],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',


### PR DESCRIPTION
## Summary

Closes #116 — enable Jest coverage collection, commit permissive-but-real global thresholds, and record the first measured coverage number for the modernization M3 phase.

## Approach

- `collectCoverage: true` in `jest.config.cjs` — every test run (including CI's `npm test`) now prints the coverage table summary.
- Committed `coverageThreshold.global` sized just below measured numbers (statements 65 / branches 50 / functions 60 / lines 68 vs. measured 71.05 / 56.43 / 66.66 / 73.29) so it guards without blocking; to be ratcheted up as the test campaign lands (per plan Task 7.9).
- Recorded measured coverage and current pass rate (78/78) beside the baseline note in `docs/AGENT_ENV.md`.

## Decision Record

**Selected option:** Minimal (light profile, auto-selected best-balance) — config-only change plus doc update. No new tests needed since this issue is about measuring/guarding existing tests; no workflow edits because `collectCoverage` makes the standard `npm test` step emit the summary.

## Changes

| File | Change |
|------|--------|
| `jest.config.cjs` | Add `collectCoverage`, `coverageDirectory`, `coveragePathIgnorePatterns`, `coverageThreshold` |
| `docs/AGENT_ENV.md` | Record measured coverage % and current pass rate |

## Test Results

- `npm test`: 9 suites, **78/78 passing**, exit 0, coverage thresholds enforced and met.
- `npm run validate:designs`: ✓ all designs valid.

## Acceptance Criteria Verification

| Criterion | Status |
|-----------|--------|
| `npx jest --coverage` exits 0, emits summary; `coverageThreshold` present | ✅ |
| Measured coverage recorded in `docs/AGENT_ENV.md` beside pass rate | ✅ |
| `npm test` passes at ≥ baseline pass rate | ✅ (78/78 ≥ 69/69 floor) |