### PR TITLE
refactor(designs): single-source catalog registry; extract testable transform (#125)

### DIFF
--- a/src/data/designs.ts
+++ b/src/data/designs.ts
@@ -1,105 +1,28 @@
 import type { TransformedDesign, DesignData } from '../types/design';
-
-const GITHUB_PAGES_BASE = 'https://luongnv.com/sleek-ui';
-
-const transformDesign = (designJson: DesignData): TransformedDesign => {
-  const slug = designJson.name;
-  const mode = designJson.defaultMode || 'light';
-  const colors = designJson.tokens?.colors?.[mode] || designJson.tokens?.colors?.light || {};
-
-  return {
-    slug,
-    name: designJson.name,
-    categories: designJson.categories || [],
-    colors: {
-      primary: colors.primary || '',
-      secondary: colors.secondary || '',
-    },
-    defaultMode: (designJson.defaultMode || 'light') as 'light' | 'dark',
-    jsonUrl: `${GITHUB_PAGES_BASE}/designs/${slug}.json`,
-    thumbnailUrl: designJson.preview?.thumbnail
-      ? `${GITHUB_PAGES_BASE}${designJson.preview.thumbnail}`
-      : `${GITHUB_PAGES_BASE}/previews/${slug}-thumb.svg`,
-    detailUrl: `/designs/${slug}`,
-    description: designJson.tokens?.typography?.fontFamily?.sans
-      ? `A ${designJson.tokens.typography.fontFamily.sans} based design system`
-      : 'A beautiful design system',
-    rawData: designJson,
-  };
-};
-
-const DESIGN_LIST = [
-  'neo-brutalist',
-  'warm-saas',
-  'editorial-dark',
-  'swiss-clean',
-  'deep-ocean',
-  'glassmorphic',
-  'airbnb',
-  'airtable',
-  'apple',
-  'bmw',
-  'cal',
-  'claude',
-  'clay',
-  'clickhouse',
-  'cohere',
-  'coinbase',
-  'composio',
-  'cursor',
-  'elevenlabs',
-  'expo',
-  'figma',
-  'framer',
-  'hashicorp',
-  'ibm',
-  'intercom',
-  'kraken',
-  'linear.app',
-  'lovable',
-  'minimax',
-  'mintlify',
-  'miro',
-  'mistral.ai',
-  'mongodb',
-  'notion',
-  'nvidia',
-  'ollama',
-  'opencode.ai',
-  'pinterest',
-  'posthog',
-  'raycast',
-  'replicate',
-  'resend',
-  'revolut',
-  'runwayml',
-  'sanity',
-  'sentry',
-  'spacex',
-  'spotify',
-  'stripe',
-  'supabase',
-  'superhuman',
-  'together.ai',
-  'uber',
-  'vercel',
-  'voltagent',
-  'warp',
-  'webflow',
-  'wise',
-  'x.ai',
-  'zapier',
-];
+import { transformDesign } from '../lib/transformDesign';
 
 const designModules = import.meta.glob('./designs/*.json', { eager: true });
 
-const designs: TransformedDesign[] = DESIGN_LIST.map(slug => {
-  const moduleKey = `./designs/${slug}.json`;
-  const designJson = designModules[moduleKey] as DesignData;
-  if (designJson) {
-    return transformDesign(designJson);
-  }
-  return null;
-}).filter((d): d is TransformedDesign => d !== null);
+const isDev = import.meta.env?.DEV ?? false;
+
+const designs: TransformedDesign[] = Object.keys(designModules)
+  .sort()
+  .map(moduleKey => {
+    try {
+      const designJson = designModules[moduleKey] as DesignData;
+      if (!designJson || !designJson.name) {
+        throw new Error('missing or invalid design JSON');
+      }
+      return transformDesign(designJson);
+    } catch (err) {
+      if (isDev) {
+        console.warn(
+          `[designs] Dropping ${moduleKey}: ${err instanceof Error ? err.message : String(err)}`
+        );
+      }
+      return null;
+    }
+  })
+  .filter((d): d is TransformedDesign => d !== null);
 
 export default designs;

--- a/src/lib/transformDesign.test.ts
+++ b/src/lib/transformDesign.test.ts
@@ -1,0 +1,109 @@
+import { transformDesign } from './transformDesign';
+import type { DesignData } from '../types/design';
+
+const makeDesign = (overrides: Partial<DesignData> = {}): DesignData =>
+  ({
+    name: 'test-design',
+    version: '1.0.0',
+    description: 'A test design system',
+    categories: ['test'],
+    tokens: {
+      colors: {
+        light: {
+          background: '0 0% 100%',
+          foreground: '240 10% 3.9%',
+          primary: '245 90% 73%',
+          secondary: '240 4.8% 95.9%',
+        },
+        dark: {
+          background: '240 10% 8%',
+          foreground: '0 0% 95%',
+          primary: '245 90% 73%',
+          secondary: '240 33% 19%',
+        },
+      },
+      typography: {
+        fontFamily: { sans: 'Inter' },
+      },
+    },
+    defaultMode: 'light',
+    ...overrides,
+  }) as DesignData;
+
+describe('transformDesign', () => {
+  it('maps slug and name from the design name field', () => {
+    const result = transformDesign(makeDesign({ name: 'my-design' }));
+    expect(result.slug).toBe('my-design');
+    expect(result.name).toBe('my-design');
+  });
+
+  it('uses light mode colors by default', () => {
+    const result = transformDesign(makeDesign());
+    expect(result.colors.primary).toBe('245 90% 73%');
+    expect(result.colors.secondary).toBe('240 4.8% 95.9%');
+    expect(result.defaultMode).toBe('light');
+  });
+
+  it('falls back to light palette when defaultMode is dark but dark colors are absent', () => {
+    const design = makeDesign({ defaultMode: 'dark' });
+    delete (design.tokens!.colors as unknown as Record<string, unknown>).dark;
+    const result = transformDesign(design);
+    expect(result.defaultMode).toBe('dark');
+    expect(result.colors.primary).toBe('245 90% 73%');
+  });
+
+  it('builds json and thumbnail URLs from the GitHub Pages base', () => {
+    const result = transformDesign(makeDesign({ name: 'url-check' }));
+    expect(result.jsonUrl).toBe(
+      'https://luongnv.com/sleek-ui/designs/url-check.json'
+    );
+    expect(result.thumbnailUrl).toBe(
+      'https://luongnv.com/sleek-ui/previews/url-check-thumb.svg'
+    );
+    expect(result.detailUrl).toBe('/designs/url-check');
+  });
+
+  it('prefers an explicit preview.thumbnail path over the generated one', () => {
+    const result = transformDesign(
+      makeDesign({
+        preview: {
+          thumbnail: '/previews/custom.svg',
+          screenshots: {},
+        },
+      })
+    );
+    expect(result.thumbnailUrl).toBe(
+      'https://luongnv.com/sleek-ui/previews/custom.svg'
+    );
+  });
+
+  it('derives description from typography sans font family when present', () => {
+    const result = transformDesign(makeDesign());
+    expect(result.description).toBe('A Inter based design system');
+  });
+
+  it('falls back to a generic description without a sans font family', () => {
+    const design = makeDesign();
+    delete (design.tokens!.typography!.fontFamily as { sans?: string }).sans;
+    const result = transformDesign(design);
+    expect(result.description).toBe('A beautiful design system');
+  });
+
+  it('defaults categories to an empty list and keeps provided ones', () => {
+    expect(transformDesign(makeDesign()).categories).toEqual(['test']);
+    expect(transformDesign(makeDesign({ categories: undefined })).categories).toEqual([]);
+  });
+
+  it('returns empty color strings when tokens are missing entirely', () => {
+    const design = makeDesign();
+    (design as { tokens?: unknown }).tokens = undefined;
+    const result = transformDesign(design);
+    expect(result.colors).toEqual({ primary: '', secondary: '' });
+  });
+
+  it('keeps a reference to the raw design data', () => {
+    const design = makeDesign();
+    const result = transformDesign(design);
+    expect(result.rawData).toBe(design);
+  });
+});

--- a/src/lib/transformDesign.ts
+++ b/src/lib/transformDesign.ts
@@ -1,0 +1,29 @@
+import type { TransformedDesign, DesignData } from '../types/design';
+
+const GITHUB_PAGES_BASE = 'https://luongnv.com/sleek-ui';
+
+export const transformDesign = (designJson: DesignData): TransformedDesign => {
+  const slug = designJson.name;
+  const mode = designJson.defaultMode || 'light';
+  const colors = designJson.tokens?.colors?.[mode] || designJson.tokens?.colors?.light || {};
+
+  return {
+    slug,
+    name: designJson.name,
+    categories: designJson.categories || [],
+    colors: {
+      primary: colors.primary || '',
+      secondary: colors.secondary || '',
+    },
+    defaultMode: (designJson.defaultMode || 'light') as 'light' | 'dark',
+    jsonUrl: `${GITHUB_PAGES_BASE}/designs/${slug}.json`,
+    thumbnailUrl: designJson.preview?.thumbnail
+      ? `${GITHUB_PAGES_BASE}${designJson.preview.thumbnail}`
+      : `${GITHUB_PAGES_BASE}/previews/${slug}-thumb.svg`,
+    detailUrl: `/designs/${slug}`,
+    description: designJson.tokens?.typography?.fontFamily?.sans
+      ? `A ${designJson.tokens.typography.fontFamily.sans} based design system`
+      : 'A beautiful design system',
+    rawData: designJson,
+  };
+};


### PR DESCRIPTION
## Summary

Resolves #125 — removes the hand-duplicated slug registry between `src/data/designs.ts` and `scripts/ingest-designs.js`, and extracts the design-transform logic into a directly unit-testable module.

## Approach

- **Registry derived from files:** `src/data/designs.ts` no longer hardcodes a 61-entry `DESIGN_LIST`. The runtime catalog is derived from the `import.meta.glob('./designs/*.json')` keys, so dropping a fixture JSON into `public/designs/` (mirrored to `src/data/designs/`) appears in the catalog with zero list edits. In development (`import.meta.env.DEV`) any module that fails to load or transform logs a `[designs] Dropping <file>` warning instead of vanishing silently.
- **Canonical ownership:** `scripts/ingest-designs.js` remains the sole owner of what gets ingested into `public/designs/`; the app now trusts the files, eliminating drift between the two registries.
- **Testable transform:** all transform logic moved verbatim to `src/lib/transformDesign.ts` — a pure function with no `import.meta.glob` dependency, exercised directly by Jest.

## Decision Record

- **Context:** Dual hardcoded slug lists drifted silently; transform logic was untestable behind `import.meta.glob`.
- **Options considered:**
  1. *Minimal* — keep both lists, add a sync-check script (still two sources of truth).
  2. **Balanced (selected)** — glob-derived registry + extracted pure transform + dev-mode drop warnings.
  3. *Comprehensive* — additionally refactor the ingest script into a manifest-driven pipeline writing a generated registry file (larger blast radius, not required by acceptance criteria).
- **Selected option:** Balanced — meets all three acceptance criteria with minimal surface change.
- **Accepted behavior change:** catalog ordering shifts from curated hand-list order to deterministic alphabetical (slug-sorted) order. No downstream component sorts; re-introducing curated order would require another hardcoded list, defeating the issue's goal.

## Changes

| File | Change |
|------|--------|
| `src/lib/transformDesign.ts` | New — pure `transformDesign()` extracted from `designs.ts` (logic unchanged) |
| `src/data/designs.ts` | Registry derived from glob keys; dev-only drop warnings; imports shared transform |
| `src/lib/transformDesign.test.ts` | New — 10 direct unit tests (no `import.meta.glob` in tested unit) |

## Test Results

- `npm test`: **10 suites, 88 tests passed** (10 new; baseline-green holds) — `transformDesign.ts` at 100% statement coverage
- `npm run typecheck`: clean
- `npm run lint`: clean
- `npm run validate:designs`: ✓ All designs are valid
- `npm run build`: ✓ built in 1.44s

## Acceptance Criteria Verification

| Criterion | Status |
|-----------|--------|
| Dropping a fixture JSON into public/designs/ appears in catalog without editing either hardcoded list; dev mode logs any slug whose bundled module fails to load | ✅ Glob-derived registry; dev `console.warn` on dropped modules |
| `src/lib/transformDesign.ts` exists and a Jest unit test exercises it directly (no import.meta.glob in the tested unit) | ✅ Pure module + `transformDesign.test.ts` |
| npm test passes at ≥ the pass rate recorded by Task 0.2 (baseline-green holds) | ✅ 88/88 passed, no regressions |

Closes #125