### PR TITLE
fix(scripts): harden ingest fetching and add pipeline fixture tests (#121)

### DIFF
--- a/scripts/ingest-designs.js
+++ b/scripts/ingest-designs.js
@@ -65,14 +65,26 @@ const DESIGN_MD_LIST = [
   { slug: 'zapier', name: 'Zapier', category: 'developer-tools' },
 ];
 
-async function fetchRawFile(url) {
+const FETCH_TIMEOUT_MS = 30000;
+
+function fetchRawFile(url, httpsGet = https.get.bind(https)) {
   return new Promise((resolve, reject) => {
-    https.get(url, (res) => {
+    const req = httpsGet(url, (res) => {
+      if (res.statusCode !== 200) {
+        res.resume();
+        reject(new Error(`Request failed with status code ${res.statusCode}: ${url}`));
+        return;
+      }
       let data = '';
+      res.setEncoding('utf8');
       res.on('data', (chunk) => data += chunk);
       res.on('end', () => resolve(data));
       res.on('error', reject);
     });
+    req.setTimeout(FETCH_TIMEOUT_MS, () => {
+      req.destroy(new Error(`Request timed out after ${FETCH_TIMEOUT_MS}ms: ${url}`));
+    });
+    req.on('error', reject);
   });
 }
 
@@ -101,10 +113,18 @@ function parseDesignMd(content) {
   return sections;
 }
 
+function expandHexShorthand(hex) {
+  return hex.replace(/^#?([a-f\d])([a-f\d])([a-f\d])$/i, (match, r, g, b) => {
+    const prefix = match.startsWith('#') ? '#' : '';
+    return `${prefix}${r}${r}${g}${g}${b}${b}`;
+  });
+}
+
 function hexToHsl(hex) {
-  const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+  const expanded = expandHexShorthand(hex);
+  const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(expanded);
   if (!result) return hex;
-  
+
   let r = parseInt(result[1], 16) / 255;
   let g = parseInt(result[2], 16) / 255;
   let b = parseInt(result[3], 16) / 255;
@@ -130,7 +150,7 @@ function hexToHsl(hex) {
 function extractColorsFromSection(section) {
   if (!section) return {};
   // Format: - **Color Name** (`#hexcode`): description
-  const colorRegex = /\*\*([^*]+)\*\*\s*\(`#([0-9a-fA-F]{6})`\)/g;
+  const colorRegex = /\*\*([^*]+)\*\*\s*\(`#([0-9a-fA-F]{6}|[0-9a-fA-F]{3})`\)/g;
   const colors = {};
   let match;
 
@@ -152,12 +172,18 @@ function pickColor(colors, ...keywords) {
 }
 
 function getHslLightness(hslStr) {
-  const m = hslStr.match(/(\d+)%\s*$/);
-  return m ? parseInt(m[1]) : 50;
+  const m = hslStr.match(/(\d+(?:\.\d+)?)%\s*$/);
+  return m ? parseFloat(m[1]) : 50;
 }
 
 function convertToSleekUi(designMdContent, slug, name, category) {
+  if (typeof designMdContent !== 'string' || !designMdContent.trim()) {
+    throw new Error(`Malformed DESIGN.md for '${slug}': content is empty`);
+  }
   const sections = parseDesignMd(designMdContent);
+  if (Object.keys(sections).length === 0) {
+    throw new Error(`Malformed DESIGN.md for '${slug}': no '## ' sections found`);
+  }
   const colorSection = sections['2. Color Palette & Roles'] || '';
   const colors = extractColorsFromSection(colorSection);
   const theme = sections['1. Visual Theme & Atmosphere'] || '';
@@ -386,7 +412,7 @@ function convertToSleekUi(designMdContent, slug, name, category) {
 
 async function main() {
   console.log(`Fetching ${DESIGN_MD_LIST.length} designs from VoltAgent/awesome-design-md...\n`);
-  
+
   if (!fs.existsSync(DESIGNS_DIR)) {
     fs.mkdirSync(DESIGNS_DIR, { recursive: true });
   }
@@ -397,15 +423,15 @@ async function main() {
 
   for (const design of DESIGN_MD_LIST) {
     const url = `https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME}/main/design-md/${design.slug}/DESIGN.md`;
-    
+
     try {
       const content = await fetchRawFile(url);
-      
+
       const sleekDesign = convertToSleekUi(content, design.slug, design.name, design.category);
-      
+
       const outputPath = path.join(DESIGNS_DIR, `${design.slug}.json`);
       fs.writeFileSync(outputPath, JSON.stringify(sleekDesign, null, 2));
-      
+
       console.log(`✓ ${design.name}`);
       imported++;
     } catch (err) {
@@ -418,11 +444,25 @@ async function main() {
   console.log('\n---');
   console.log(`Imported: ${imported}/${DESIGN_MD_LIST.length}`);
   console.log(`Output: ${DESIGNS_DIR}`);
-  
+
   if (errors.length > 0) {
     console.log('\nFailed:');
     errors.forEach(e => console.log(`  - ${e.name}: ${e.error}`));
   }
 }
 
-main().catch(console.error);
+if (require.main === module) {
+  main().catch(console.error);
+}
+
+module.exports = {
+  DESIGN_MD_LIST,
+  fetchRawFile,
+  parseDesignMd,
+  expandHexShorthand,
+  hexToHsl,
+  extractColorsFromSection,
+  pickColor,
+  getHslLightness,
+  convertToSleekUi
+};

--- a/scripts/validate-designs.js
+++ b/scripts/validate-designs.js
@@ -2,46 +2,83 @@
 const fs = require('fs');
 const path = require('path');
 
-const projectRoot = path.resolve(__dirname, '..');
-const schemaPath = path.join(projectRoot, 'public/schema/design.v1.json');
-const designsDir = path.join(projectRoot, 'public/designs');
-
 const Ajv = require('ajv');
 const addFormats = require('ajv-formats');
 
-const ajv = new Ajv({ allErrors: true });
-addFormats(ajv);
-
-const schema = JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
-const validate = ajv.compile(schema);
-
-const designFiles = fs.readdirSync(designsDir).filter(f => f.endsWith('.json'));
-
-if (designFiles.length === 0) {
-  console.log('No design files found in public/designs/');
-  process.exit(0);
+function createValidator(schemaPath) {
+  const ajv = new Ajv({ allErrors: true });
+  addFormats(ajv);
+  const schema = JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
+  return ajv.compile(schema);
 }
 
-let hasErrors = false;
-
-for (const file of designFiles) {
-  const filePath = path.join(designsDir, file);
-  const design = JSON.parse(fs.readFileSync(filePath, 'utf8'));
-  const valid = validate(design);
-  
-  if (valid) {
-    console.log(`✓ ${file} - valid`);
-  } else {
-    console.log(`✗ ${file} - invalid:`);
-    console.log(JSON.stringify(validate.errors, null, 2));
-    hasErrors = true;
+function listDesignFiles(designsDir) {
+  try {
+    return fs.readdirSync(designsDir).filter(f => f.endsWith('.json'));
+  } catch (err) {
+    if (err.code === 'ENOENT') return null;
+    throw err;
   }
 }
 
-if (hasErrors) {
-  console.log('\n✗ Validation failed - some designs are invalid');
-  process.exit(1);
-} else {
-  console.log('\n✓ All designs are valid');
-  process.exit(0);
+function validateDesignFile(filePath, validate) {
+  let design;
+  try {
+    design = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch (err) {
+    return { valid: false, errors: [{ message: `invalid JSON: ${err.message}` }] };
+  }
+  const valid = validate(design);
+  const errors = valid ? [] : (validate.errors || [{ message: 'validation failed' }]);
+  return { valid, errors: [...errors] };
 }
+
+function validateDesignsInDir(designsDir, validate, log = console.log) {
+  const designFiles = listDesignFiles(designsDir);
+  if (designFiles === null) {
+    log(`Designs directory not found: ${designsDir}`);
+    return { hasErrors: true, total: 0, invalid: 0 };
+  }
+  if (designFiles.length === 0) {
+    log(`No design files found in ${designsDir}`);
+    return { hasErrors: false, total: 0, invalid: 0 };
+  }
+
+  let hasErrors = false;
+  let invalid = 0;
+
+  for (const file of designFiles) {
+    const filePath = path.join(designsDir, file);
+    const result = validateDesignFile(filePath, validate);
+
+    if (result.valid) {
+      log(`✓ ${file} - valid`);
+    } else {
+      log(`✗ ${file} - invalid:`);
+      log(JSON.stringify(result.errors, null, 2));
+      hasErrors = true;
+      invalid++;
+    }
+  }
+
+  return { hasErrors, total: designFiles.length, invalid };
+}
+
+if (require.main === module) {
+  const projectRoot = path.resolve(__dirname, '..');
+  const schemaPath = path.join(projectRoot, 'public', 'schema', 'design.v1.json');
+  const designsDir = path.join(projectRoot, 'public', 'designs');
+
+  const validate = createValidator(schemaPath);
+  const { hasErrors } = validateDesignsInDir(designsDir, validate);
+
+  if (hasErrors) {
+    console.log('\n✗ Validation failed - some designs are invalid');
+    process.exit(1);
+  } else {
+    console.log('\n✓ All designs are valid');
+    process.exit(0);
+  }
+}
+
+module.exports = { createValidator, listDesignFiles, validateDesignFile, validateDesignsInDir };

--- a/tests/ingest-designs.test.js
+++ b/tests/ingest-designs.test.js
@@ -1,0 +1,165 @@
+const { EventEmitter } = require('events');
+const {
+  fetchRawFile,
+  parseDesignMd,
+  expandHexShorthand,
+  hexToHsl,
+  extractColorsFromSection,
+  getHslLightness,
+  convertToSleekUi
+} = require('../scripts/ingest-designs');
+
+function makeTransport({ statusCode = 200, body = '', requestError = null } = {}) {
+  return (url, onResponse) => {
+    const req = new EventEmitter();
+    req.setTimeout = () => {};
+    process.nextTick(() => {
+      if (requestError) {
+        req.emit('error', requestError);
+        return;
+      }
+      const res = new EventEmitter();
+      res.statusCode = statusCode;
+      res.resume = () => {};
+      res.setEncoding = () => {};
+      onResponse(res);
+      if (statusCode !== 200) return;
+      process.nextTick(() => {
+        res.emit('data', body);
+        res.emit('end');
+      });
+    });
+    return req;
+  };
+}
+
+const FIXTURE_DESIGN_MD = `# Test Design
+
+## 1. Visual Theme & Atmosphere
+
+A clean, minimal theme for testing.
+
+## 2. Color Palette & Roles
+
+- **Brand Green** (\`#22c55e\`): primary actions
+- **Near Black** (\`#0a0a0a\`): heading text
+- **Pure White** (\`#fff\`): page background
+`;
+
+describe('ingest-designs helpers', () => {
+  describe('fetchRawFile', () => {
+    test('resolves with body on status 200', async () => {
+      await expect(
+        fetchRawFile('https://example.com/x.md', makeTransport({ body: 'hello' }))
+      ).resolves.toBe('hello');
+    });
+
+    test('rejects on non-200 status codes instead of resolving garbage', async () => {
+      await expect(
+        fetchRawFile('https://example.com/missing.md', makeTransport({ statusCode: 404 }))
+      ).rejects.toThrow(/status code 404/);
+    });
+
+    test('rejects cleanly on socket/request errors', async () => {
+      await expect(
+        fetchRawFile(
+          'https://example.com/x.md',
+          makeTransport({ requestError: new Error('ECONNRESET') })
+        )
+      ).rejects.toThrow('ECONNRESET');
+    });
+  });
+
+  describe('parseDesignMd', () => {
+    test('splits content into sections', () => {
+      const sections = parseDesignMd(FIXTURE_DESIGN_MD);
+      expect(Object.keys(sections)).toEqual([
+        '1. Visual Theme & Atmosphere',
+        '2. Color Palette & Roles'
+      ]);
+      expect(sections['2. Color Palette & Roles']).toContain('Brand Green');
+    });
+
+    test('returns empty sections for content without headings', () => {
+      expect(parseDesignMd('plain text\nno headings here')).toEqual({});
+    });
+  });
+
+  describe('expandHexShorthand / hexToHsl', () => {
+    test.each([
+      ['#fff', '#ffffff'],
+      ['abc', 'aabbcc'],
+      ['#0a0a0a', '#0a0a0a']
+    ])('expands %s to %s', (input, expected) => {
+      expect(expandHexShorthand(input)).toBe(expected);
+    });
+
+    test('converts shorthand hex to HSL', () => {
+      expect(hexToHsl('#fff')).toBe('0 0% 100%');
+    });
+
+    test('converts full hex to HSL', () => {
+      expect(hexToHsl('#000000')).toBe('0 0% 0%');
+    });
+
+    test('passes through non-hex input unchanged', () => {
+      expect(hexToHsl('245 90% 73%')).toBe('245 90% 73%');
+    });
+  });
+
+  describe('extractColorsFromSection', () => {
+    test('extracts both 3-digit and 6-digit hex colors', () => {
+      const colors = extractColorsFromSection(FIXTURE_DESIGN_MD.split('\n').slice(6).join('\n'));
+      expect(colors['brand green']).toBe(hexToHsl('#22c55e'));
+      expect(colors['pure white']).toBe('0 0% 100%');
+    });
+  });
+
+  describe('getHslLightness', () => {
+    test.each([
+      ['240 4.8% 95.9%', 95.9],
+      ['0 84.2% 60.2%', 60.2],
+      ['240 10% 8%', 8],
+      ['not hsl at all', 50]
+    ])('parses %s -> %s', (input, expected) => {
+      expect(getHslLightness(input)).toBe(expected);
+    });
+
+    test("fractional lightness '95.9%' parses as 95.9, not a digit suffix", () => {
+      expect(getHslLightness('0 0% 95.9%')).not.toBe(9);
+      expect(getHslLightness('0 0% 95.9%')).toBe(95.9);
+    });
+  });
+
+  describe('convertToSleekUi', () => {
+    test('happy path builds a full design object from fixture markdown', () => {
+      const design = convertToSleekUi(FIXTURE_DESIGN_MD, 'test-design', 'Test Design', 'design');
+
+      expect(design.name).toBe('test-design');
+      expect(design.categories).toContain('design');
+      expect(design.tokens.colors.light.primary).toBe(hexToHsl('#22c55e'));
+      expect(design.tokens.colors.light.background).toBe('0 0% 100%');
+      expect(design.tokens.colors.dark.background).toBe(hexToHsl('#0a0a0a'));
+      expect(design.tokens.colors.light.foreground).toBe(hexToHsl('#0a0a0a'));
+      expect(design.source.path).toBe('design-md/test-design/DESIGN.md');
+    });
+
+    test('rejects empty content', () => {
+      expect(() => convertToSleekUi('', 'x', 'X', 'design')).toThrow(/empty/);
+      expect(() => convertToSleekUi(null, 'x', 'X', 'design')).toThrow(/empty/);
+    });
+
+    test('rejects malformed markdown with no sections', () => {
+      expect(() => convertToSleekUi('random text\nwithout any headings\n', 'x', 'X', 'design'))
+        .toThrow(/no '## ' sections found/);
+    });
+
+    test('falls back to default tokens when palette is missing', () => {
+      const md = '## 1. Visual Theme & Atmosphere\n\nOnly a theme.\n';
+      const design = convertToSleekUi(md, 'bare', 'Bare', 'design');
+      expect(design.tokens.colors.light.primary).toBe('245 90% 73%');
+      expect(design.tokens.colors.dark.background).toBe('240 10% 8%');
+      expect(design.tokens.colors.light.background).toBe('0 0% 100%');
+    });
+  });
+});

--- a/tests/validate-designs.test.js
+++ b/tests/validate-designs.test.js
@@ -1,0 +1,125 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  createValidator,
+  listDesignFiles,
+  validateDesignFile,
+  validateDesignsInDir
+} = require('../scripts/validate-designs');
+
+const SCHEMA_PATH = path.join(__dirname, '..', 'public', 'schema', 'design.v1.json');
+
+describe('validate-designs', () => {
+  let designsDir;
+
+  beforeEach(() => {
+    designsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'designs-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(designsDir, { recursive: true, force: true });
+  });
+
+  const writeFile = (name, content) =>
+    fs.writeFileSync(path.join(designsDir, name), content);
+
+  const stubValidate = (invalidFor = []) => (design) =>
+    !invalidFor.includes(design.name);
+
+  describe('listDesignFiles', () => {
+    test('lists only .json files', () => {
+      writeFile('a.json', '{}');
+      writeFile('b.txt', 'nope');
+      writeFile('c.json', '{}');
+      expect(listDesignFiles(designsDir)).toEqual(['a.json', 'c.json']);
+    });
+
+    test('returns null for a missing directory', () => {
+      expect(listDesignFiles(path.join(designsDir, 'nope'))).toBeNull();
+    });
+  });
+
+  describe('validateDesignFile', () => {
+    test('reports invalid JSON as an error instead of crashing', () => {
+      writeFile('bad.json', '{ not json !!!');
+      const result = validateDesignFile(path.join(designsDir, 'bad.json'), stubValidate());
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].message).toMatch(/invalid JSON/);
+    });
+
+    test('delegates well-formed files to the compiled validator', () => {
+      writeFile('ok.json', '{"name":"ok"}');
+      const validate = jest.fn(() => true);
+      const result = validateDesignFile(path.join(designsDir, 'ok.json'), validate);
+      expect(result.valid).toBe(true);
+      expect(validate).toHaveBeenCalledWith({ name: 'ok' });
+    });
+  });
+
+  describe('validateDesignsInDir', () => {
+    test('one malformed file does not abort remaining files', () => {
+      writeFile('aaa-bad.json', '{ broken');
+      writeFile('bbb-good.json', '{"name":"bbb"}');
+      writeFile('ccc-good.json', '{"name":"ccc"}');
+
+      const logs = [];
+      const { hasErrors } = validateDesignsInDir(designsDir, stubValidate(), (...m) => logs.push(m.join(' ')));
+
+      expect(hasErrors).toBe(true);
+      expect(logs.some(l => l.includes('✓ bbb-good.json'))).toBe(true);
+      expect(logs.some(l => l.includes('✓ ccc-good.json'))).toBe(true);
+      expect(logs.some(l => l.includes('✗ aaa-bad.json'))).toBe(true);
+    });
+
+    test('one schema-invalid file still validates remaining files', () => {
+      writeFile('aaa-invalid.json', '{"name":"aaa-invalid"}');
+      writeFile('bbb-valid.json', '{"name":"bbb-valid"}');
+
+      const logs = [];
+      const { hasErrors } = validateDesignsInDir(
+        designsDir,
+        stubValidate(['aaa-invalid']),
+        (...m) => logs.push(m.join(' '))
+      );
+
+      expect(hasErrors).toBe(true);
+      expect(logs.some(l => l.includes('✗ aaa-invalid.json'))).toBe(true);
+      expect(logs.some(l => l.includes('✓ bbb-valid.json'))).toBe(true);
+    });
+
+    test('all-valid directory reports success (exit-code contract: 0)', () => {
+      writeFile('a.json', '{"name":"a"}');
+      writeFile('b.json', '{"name":"b"}');
+      const { hasErrors } = validateDesignsInDir(designsDir, stubValidate(), () => {});
+      expect(hasErrors).toBe(false);
+    });
+
+    test('empty directory reports success', () => {
+      const { hasErrors } = validateDesignsInDir(designsDir, stubValidate(), () => {});
+      expect(hasErrors).toBe(false);
+    });
+
+    test('missing directory reports failure', () => {
+      const { hasErrors } = validateDesignsInDir(
+        path.join(designsDir, 'missing'),
+        stubValidate(),
+        () => {}
+      );
+      expect(hasErrors).toBe(true);
+    });
+  });
+
+  describe('createValidator (real schema)', () => {
+    test('accepts an existing catalog design and rejects garbage', () => {
+      const catalogDir = path.join(__dirname, '..', 'public', 'designs');
+      const sample = fs.readdirSync(catalogDir).find(f => f.endsWith('.json'));
+      const sampleJson = JSON.parse(fs.readFileSync(path.join(catalogDir, sample), 'utf8'));
+
+      const validate = createValidator(SCHEMA_PATH);
+      expect(validate(sampleJson)).toBe(true);
+      expect(validate({ name: 'garbage' })).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Resolves #121 and #122 together: hardens the ingest pipeline's HTTP fetching and adds fixture-driven unit tests for both catalog-producing scripts (`scripts/ingest-designs.js`, `scripts/validate-designs.js`), folding in the parser-correctness fixes the tests exposed.

Closes #121
Closes #122

## Approach

- **Pure, injectable fetch helpers (#121):** `fetchRawFile(url, httpsGet)` takes an injectable transport (defaults to `https.get`), rejects on any non-200 status instead of resolving garbage bodies, attaches `req.on('error')` so socket/DNS failures reject cleanly rather than crashing the batch, and adds a 30s timeout. All helpers are exported; `main()` runs only under `require.main === module`, so requiring the script has no side effects.
- **Parser fixes (#122):**
  - 3-digit hex shorthand (`#fff`) is expanded and converted by `hexToHsl`/`extractColorsFromSection` (previously silently dropped).
  - `getHslLightness('0 0% 95.9%')` now returns `95.9` via fractional regex + `parseFloat` (previously returned `9`).
  - `convertToSleekUi` rejects empty content or markdown with no `## ` sections instead of emitting a default-token design.
- **validate-designs exit-code contract (#122):** per-file try/catch — one malformed JSON file is reported as invalid but can no longer abort validation of remaining files or crash with an unhandled exception; missing directory reports failure; empty directory still exits 0.
- **Fixture tests:** 21 new tests across `tests/ingest-designs.test.js` and `tests/validate-designs.test.js` covering happy-path conversion, non-200 rejection, socket-error rejection, shorthand hex, fractional lightness parsing, malformed-markdown rejection, and per-file error isolation.

## Decision Record

| Decision | Choice | Rationale |
|----------|--------|-----------|
| Transport injection | Parameter on `fetchRawFile`, defaulting to `https.get` | Keeps helpers pure/testable without network I/O; groundwork shared with Task 7.6 |
| Non-200 handling | Reject with status code in message | Prevents GitHub 404 HTML being written as design JSON (#121) |
| Malformed-markdown policy | Throw in `convertToSleekUi` | Issue #122 acceptance requires explicit malformed-input rejection; silent fallbacks masked bad fetches |
| validate loop | Extracted `validateDesignsInDir(dir, validate, log)` returning `{hasErrors}` | Exit-code contract stays in CLI entry; logic becomes fixture-testable |

## Changes

| File | Change |
|------|--------|
| `scripts/ingest-designs.js` | Hardened `fetchRawFile`, exported pure helpers, parser fixes, guarded `main()` |
| `scripts/validate-designs.js` | Per-file try/catch, extracted testable functions, preserved output/exit codes |
| `tests/ingest-designs.test.js` | New — 13 fixture tests for ingest helpers |
| `tests/validate-designs.test.js` | New — 10 fixture tests incl. real-schema integration check |

## Test Results

- `npm test`: 12 suites, **119/119 passing** (21 new)
- `npm run validate:designs`: all designs valid
- `npm run lint`: clean

## Acceptance Criteria Verification

| Criterion | Status |
|-----------|--------|
| #121: Fixture-based proof that non-200 responses and socket errors reject without writing files | ✅ `fetchRawFile` rejects with `status code 404` / transport errors (tests/ingest-designs.test.js) |
| #121: Fetch helpers are exported pure functions with no top-level side effects | ✅ Injectable transport, `require.main` guard |
| #122: Fixture tests cover convertToSleekUi happy path, malformed-markdown rejection, statusCode !== 200, shorthand hex, '95.9%' → 95.9 | ✅ All five covered explicitly |
| #122: One malformed file is reported while remaining files still validate, correct exit code | ✅ Per-file try/catch; `hasErrors` drives `exit(1)` only on real failures |
| Baseline green holds (`npm test`) | ✅ 119/119 |