### PR TITLE
refactor(scripts): split convertToSleekUi into pure helpers (#131)

### DIFF
--- a/scripts/ingest-designs.js
+++ b/scripts/ingest-designs.js
@@ -176,6 +176,272 @@ function getHslLightness(hslStr) {
   return m ? parseFloat(m[1]) : 50;
 }
 
+// Pure: reads `colors` without mutating it; sorts operate on fresh copies.
+function pickThemeColors(colors) {
+  const values = Object.values(colors);
+  const darkest = [...values].sort((a, b) => getHslLightness(a) - getHslLightness(b))[0];
+  const lightest = [...values].sort((a, b) => getHslLightness(b) - getHslLightness(a))[0];
+
+  return {
+    primary:
+      pickColor(colors, 'brand', 'primary', 'accent', 'green', 'red', 'blue', 'purple', 'orange') ||
+      values[0] ||
+      '245 90% 73%',
+    darkBg:
+      pickColor(colors, 'black', 'near black', 'darkest', 'dark surface', 'background') ||
+      darkest ||
+      '240 10% 8%',
+    lightBg:
+      pickColor(colors, 'white', 'pure white', 'light surface', 'light background') ||
+      lightest ||
+      '0 0% 100%',
+    fg:
+      pickColor(colors, 'near black', 'heading', 'primary text', 'foreground', 'body') ||
+      '240 10% 3.9%'
+  };
+}
+
+function buildColorTokens({ primary, darkBg, lightBg, fg }) {
+  return {
+    light: {
+      background: lightBg,
+      foreground: fg,
+      muted: '240 4.8% 95.9%',
+      'muted-foreground': '240 3.8% 46.1%',
+      primary,
+      'primary-foreground': '0 0% 100%',
+      secondary: '240 4.8% 95.9%',
+      'secondary-foreground': '240 10% 3.9%',
+      accent: '240 4.8% 95.9%',
+      'accent-foreground': '240 10% 3.9%',
+      destructive: '0 84.2% 60.2%',
+      'destructive-foreground': '0 0% 100%',
+      border: '240 5.9% 90%',
+      input: '240 5.9% 90%',
+      ring: primary,
+      card: '0 0% 100%',
+      'card-foreground': '240 10% 3.9%'
+    },
+    dark: {
+      background: darkBg,
+      foreground: '0 0% 95%',
+      muted: '240 33% 19%',
+      'muted-foreground': '240 5% 64.9%',
+      primary,
+      'primary-foreground': '0 0% 100%',
+      secondary: '240 33% 19%',
+      'secondary-foreground': '0 0% 95%',
+      accent: '240 33% 19%',
+      'accent-foreground': '0 0% 95%',
+      destructive: '0 62.8% 30.6%',
+      'destructive-foreground': '0 0% 100%',
+      border: '240 33% 22%',
+      input: '240 33% 22%',
+      ring: primary,
+      card: '240 33% 17%',
+      'card-foreground': '0 0% 95%'
+    }
+  };
+}
+
+function buildTypographyTokens() {
+  return {
+    fontFamily: {
+      sans: 'Inter',
+      serif: 'Georgia',
+      mono: 'JetBrains Mono'
+    },
+    fontSize: {
+      xs: '0.75rem',
+      sm: '0.875rem',
+      base: '1rem',
+      lg: '1.125rem',
+      xl: '1.25rem',
+      '2xl': '1.5rem',
+      '3xl': '1.875rem',
+      '4xl': '2.25rem'
+    },
+    fontWeight: {
+      normal: 400,
+      medium: 500,
+      semibold: 600,
+      bold: 700
+    },
+    lineHeight: {
+      tight: '1.25',
+      normal: '1.5',
+      relaxed: '1.625'
+    },
+    letterSpacing: {
+      tight: '-0.025em',
+      normal: '0',
+      wide: '0.025em'
+    }
+  };
+}
+
+function buildSpaceTokens() {
+  return {
+    spacing: {
+      unit: '8px',
+      xs: '4px',
+      sm: '8px',
+      md: '16px',
+      lg: '24px',
+      xl: '32px',
+      '2xl': '48px'
+    },
+    radius: {
+      sm: '0.125rem',
+      default: '0.375rem',
+      lg: '0.5rem',
+      full: '9999px'
+    },
+    shadows: {
+      sm: '0 1px 2px 0 rgb(0 0 0 / 0.05)',
+      default: '0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1)',
+      lg: '0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)'
+    }
+  };
+}
+
+function buildTokens(themeColors) {
+  return {
+    colors: buildColorTokens(themeColors),
+    typography: buildTypographyTokens(),
+    ...buildSpaceTokens()
+  };
+}
+
+function buildFonts() {
+  return {
+    google: [
+      { family: 'Inter', weights: [400, 500, 600, 700] }
+    ],
+    urls: [
+      {
+        url: 'https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap',
+        format: 'css2',
+        family: 'Inter'
+      }
+    ]
+  };
+}
+
+function buildAccessibility() {
+  return {
+    contrastTarget: 4.5,
+    focusRing: {
+      width: '2px',
+      color: 'currentColor',
+      offset: '2px'
+    },
+    reducedMotion: true
+  };
+}
+
+function buildComponentTokens() {
+  return {
+    button: {
+      primary: {
+        background: 'primary',
+        color: 'primary-foreground',
+        borderRadius: 'radius.default',
+        padding: 'spacing.sm spacing.md',
+        fontWeight: 'semibold'
+      },
+      secondary: {
+        background: 'secondary',
+        color: 'secondary-foreground',
+        borderRadius: 'radius.default',
+        padding: 'spacing.sm spacing.md',
+        fontWeight: 'medium'
+      },
+      ghost: {
+        background: 'transparent',
+        color: 'foreground',
+        borderRadius: 'radius.default',
+        padding: 'spacing.sm spacing.md',
+        fontWeight: 'medium'
+      }
+    },
+    card: {
+      background: 'card',
+      color: 'card-foreground',
+      borderRadius: 'radius.lg',
+      padding: 'spacing.lg',
+      shadow: 'shadows.default',
+      border: '1px solid border'
+    },
+    input: {
+      background: 'background',
+      color: 'foreground',
+      borderRadius: 'radius.default',
+      padding: 'spacing.sm spacing.md',
+      border: '1px solid input',
+      focusRing: 'focusRing',
+      placeholderColor: 'muted-foreground'
+    }
+  };
+}
+
+function buildAgentInstructions() {
+  return {
+    defaultMode: 'dark',
+    steps: [
+      `Set CSS custom properties from tokens.colors on :root (light) and .dark (dark mode)`,
+      'Set --radius from tokens.radius.default',
+      'Load fonts by adding the Google Fonts URL from fonts.urls as a <link> tag',
+      'Set font-family from tokens.typography.fontFamily',
+      'Apply component styles from the components field',
+      'Ensure focus states match accessibility.focusRing specification',
+      'Test both light and dark modes'
+    ]
+  };
+}
+
+function buildPreview(slug) {
+  return {
+    thumbnail: `/previews/${slug}-thumb.svg`,
+    screenshots: {
+      light: [`/previews/${slug}-light.svg`],
+      dark: [`/previews/${slug}-dark.svg`]
+    }
+  };
+}
+
+function buildSource(slug, importedAt) {
+  return {
+    repo: `https://github.com/${REPO_OWNER}/${REPO_NAME}`,
+    path: `design-md/${slug}/DESIGN.md`,
+    importedAt
+  };
+}
+
+// Pure template builder: assembles the design object from already-picked values.
+function buildSleekUiTemplate({ slug, name, category, theme, themeColors, importedAt }) {
+  const design = {
+    $schema: 'https://luongnv.com/sleek-ui/schema/design.v1.json',
+    name: slug,
+    version: '1.0.0',
+    description: theme.slice(0, 200) || `${name} design system for AI agents`,
+    categories: [category, 'dark'],
+    author: {
+      name: 'VoltAgent',
+      url: 'https://github.com/VoltAgent/awesome-design-md'
+    },
+    tokens: buildTokens(themeColors),
+    fonts: buildFonts(),
+    accessibility: buildAccessibility(),
+    components: buildComponentTokens(),
+    agentInstructions: buildAgentInstructions(),
+    preview: buildPreview(slug),
+    source: buildSource(slug, importedAt)
+  };
+
+  return design;
+}
+
 function convertToSleekUi(designMdContent, slug, name, category) {
   if (typeof designMdContent !== 'string' || !designMdContent.trim()) {
     throw new Error(`Malformed DESIGN.md for '${slug}': content is empty`);
@@ -187,227 +453,16 @@ function convertToSleekUi(designMdContent, slug, name, category) {
   const colorSection = sections['2. Color Palette & Roles'] || '';
   const colors = extractColorsFromSection(colorSection);
   const theme = sections['1. Visual Theme & Atmosphere'] || '';
+  const themeColors = pickThemeColors(colors);
 
-  const allValues = Object.values(colors);
-
-  // Pick primary: first color in the palette (usually the main brand color)
-  const primary =
-    pickColor(colors, 'brand', 'primary', 'accent', 'green', 'red', 'blue', 'purple', 'orange') ||
-    allValues[0] ||
-    '245 90% 73%';
-
-  // Pick dark bg: darkest color (lowest lightness)
-  const darkBg =
-    pickColor(colors, 'black', 'near black', 'darkest', 'dark surface', 'background') ||
-    allValues.sort((a, b) => getHslLightness(a) - getHslLightness(b))[0] ||
-    '240 10% 8%';
-
-  // Pick light bg: lightest color
-  const lightBg =
-    pickColor(colors, 'white', 'pure white', 'light surface', 'light background') ||
-    allValues.sort((a, b) => getHslLightness(b) - getHslLightness(a))[0] ||
-    '0 0% 100%';
-
-  // Pick foreground: darkest non-background color for light mode
-  const fg =
-    pickColor(colors, 'near black', 'heading', 'primary text', 'foreground', 'body') ||
-    '240 10% 3.9%';
-
-  const design = {
-    $schema: 'https://luongnv.com/sleek-ui/schema/design.v1.json',
-    name: slug,
-    version: '1.0.0',
-    description: theme.slice(0, 200) || `${name} design system for AI agents`,
-    categories: [category, 'dark'],
-    author: {
-      name: 'VoltAgent',
-      url: 'https://github.com/VoltAgent/awesome-design-md'
-    },
-    tokens: {
-      colors: {
-        light: {
-          background: lightBg,
-          foreground: fg,
-          muted: '240 4.8% 95.9%',
-          'muted-foreground': '240 3.8% 46.1%',
-          primary,
-          'primary-foreground': '0 0% 100%',
-          secondary: '240 4.8% 95.9%',
-          'secondary-foreground': '240 10% 3.9%',
-          accent: '240 4.8% 95.9%',
-          'accent-foreground': '240 10% 3.9%',
-          destructive: '0 84.2% 60.2%',
-          'destructive-foreground': '0 0% 100%',
-          border: '240 5.9% 90%',
-          input: '240 5.9% 90%',
-          ring: primary,
-          card: '0 0% 100%',
-          'card-foreground': '240 10% 3.9%'
-        },
-        dark: {
-          background: darkBg,
-          foreground: '0 0% 95%',
-          muted: '240 33% 19%',
-          'muted-foreground': '240 5% 64.9%',
-          primary,
-          'primary-foreground': '0 0% 100%',
-          secondary: '240 33% 19%',
-          'secondary-foreground': '0 0% 95%',
-          accent: '240 33% 19%',
-          'accent-foreground': '0 0% 95%',
-          destructive: '0 62.8% 30.6%',
-          'destructive-foreground': '0 0% 100%',
-          border: '240 33% 22%',
-          input: '240 33% 22%',
-          ring: primary,
-          card: '240 33% 17%',
-          'card-foreground': '0 0% 95%'
-        }
-      },
-      typography: {
-        fontFamily: {
-          sans: 'Inter',
-          serif: 'Georgia',
-          mono: 'JetBrains Mono'
-        },
-        fontSize: {
-          xs: '0.75rem',
-          sm: '0.875rem',
-          base: '1rem',
-          lg: '1.125rem',
-          xl: '1.25rem',
-          '2xl': '1.5rem',
-          '3xl': '1.875rem',
-          '4xl': '2.25rem'
-        },
-        fontWeight: {
-          normal: 400,
-          medium: 500,
-          semibold: 600,
-          bold: 700
-        },
-        lineHeight: {
-          tight: '1.25',
-          normal: '1.5',
-          relaxed: '1.625'
-        },
-        letterSpacing: {
-          tight: '-0.025em',
-          normal: '0',
-          wide: '0.025em'
-        }
-      },
-      spacing: {
-        unit: '8px',
-        xs: '4px',
-        sm: '8px',
-        md: '16px',
-        lg: '24px',
-        xl: '32px',
-        '2xl': '48px'
-      },
-      radius: {
-        sm: '0.125rem',
-        default: '0.375rem',
-        lg: '0.5rem',
-        full: '9999px'
-      },
-      shadows: {
-        sm: '0 1px 2px 0 rgb(0 0 0 / 0.05)',
-        default: '0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1)',
-        lg: '0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)'
-      }
-    },
-    fonts: {
-      google: [
-        { family: 'Inter', weights: [400, 500, 600, 700] }
-      ],
-      urls: [
-        {
-          url: 'https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap',
-          format: 'css2',
-          family: 'Inter'
-        }
-      ]
-    },
-    accessibility: {
-      contrastTarget: 4.5,
-      focusRing: {
-        width: '2px',
-        color: 'currentColor',
-        offset: '2px'
-      },
-      reducedMotion: true
-    },
-    components: {
-      button: {
-        primary: {
-          background: 'primary',
-          color: 'primary-foreground',
-          borderRadius: 'radius.default',
-          padding: 'spacing.sm spacing.md',
-          fontWeight: 'semibold'
-        },
-        secondary: {
-          background: 'secondary',
-          color: 'secondary-foreground',
-          borderRadius: 'radius.default',
-          padding: 'spacing.sm spacing.md',
-          fontWeight: 'medium'
-        },
-        ghost: {
-          background: 'transparent',
-          color: 'foreground',
-          borderRadius: 'radius.default',
-          padding: 'spacing.sm spacing.md',
-          fontWeight: 'medium'
-        }
-      },
-      card: {
-        background: 'card',
-        color: 'card-foreground',
-        borderRadius: 'radius.lg',
-        padding: 'spacing.lg',
-        shadow: 'shadows.default',
-        border: '1px solid border'
-      },
-      input: {
-        background: 'background',
-        color: 'foreground',
-        borderRadius: 'radius.default',
-        padding: 'spacing.sm spacing.md',
-        border: '1px solid input',
-        focusRing: 'focusRing',
-        placeholderColor: 'muted-foreground'
-      }
-    },
-    agentInstructions: {
-      defaultMode: 'dark',
-      steps: [
-        `Set CSS custom properties from tokens.colors on :root (light) and .dark (dark mode)`,
-        'Set --radius from tokens.radius.default',
-        'Load fonts by adding the Google Fonts URL from fonts.urls as a <link> tag',
-        'Set font-family from tokens.typography.fontFamily',
-        'Apply component styles from the components field',
-        'Ensure focus states match accessibility.focusRing specification',
-        'Test both light and dark modes'
-      ]
-    },
-    preview: {
-      thumbnail: `/previews/${slug}-thumb.svg`,
-      screenshots: {
-        light: [`/previews/${slug}-light.svg`],
-        dark: [`/previews/${slug}-dark.svg`]
-      }
-    },
-    source: {
-      repo: `https://github.com/${REPO_OWNER}/${REPO_NAME}`,
-      path: `design-md/${slug}/DESIGN.md`,
-      importedAt: new Date().toISOString()
-    }
-  };
-
-  return design;
+  return buildSleekUiTemplate({
+    slug,
+    name,
+    category,
+    theme,
+    themeColors,
+    importedAt: new Date().toISOString()
+  });
 }
 
 async function main() {
@@ -464,5 +519,7 @@ module.exports = {
   extractColorsFromSection,
   pickColor,
   getHslLightness,
+  pickThemeColors,
+  buildColorTokens,
   convertToSleekUi
 };

--- a/tests/ingest-designs.test.js
+++ b/tests/ingest-designs.test.js
@@ -6,6 +6,7 @@ const {
   hexToHsl,
   extractColorsFromSection,
   getHslLightness,
+  pickThemeColors,
   convertToSleekUi
 } = require('../scripts/ingest-designs');
 
@@ -160,6 +161,47 @@ describe('ingest-designs helpers', () => {
       expect(design.tokens.colors.light.primary).toBe('245 90% 73%');
       expect(design.tokens.colors.dark.background).toBe('240 10% 8%');
       expect(design.tokens.colors.light.background).toBe('0 0% 100%');
+    });
+  });
+
+  describe('pickThemeColors purity', () => {
+    test('selects darkest/lightest via sorted copies without mutating its input', () => {
+      const colors = {
+        'sky blue': hexToHsl('#38bdf8'),
+        'near black': hexToHsl('#0a0a0a'),
+        'pure white': '0 0% 100%',
+        'brand green': hexToHsl('#22c55e')
+      };
+      const snapshot = JSON.stringify(colors);
+
+      const picked = pickThemeColors(colors);
+
+      expect(picked.primary).toBe(hexToHsl('#22c55e'));
+      expect(picked.darkBg).toBe(hexToHsl('#0a0a0a'));
+      expect(picked.lightBg).toBe('0 0% 100%');
+      expect(JSON.stringify(colors)).toBe(snapshot);
+    });
+
+    test('does not mutate a frozen colors object (no in-place sort)', () => {
+      const colors = Object.freeze({
+        'mid gray': '240 5% 65%',
+        'deep navy': '222 47% 11%',
+        'cream': '48 33% 97%'
+      });
+
+      expect(() => pickThemeColors(colors)).not.toThrow();
+      const picked = pickThemeColors(colors);
+      expect(picked.darkBg).toBe('222 47% 11%');
+      expect(picked.lightBg).toBe('48 33% 97%');
+      expect(Object.isFrozen(colors)).toBe(true);
+    });
+
+    test('falls back to defaults on an empty palette without throwing', () => {
+      const picked = pickThemeColors({});
+      expect(picked.primary).toBe('245 90% 73%');
+      expect(picked.darkBg).toBe('240 10% 8%');
+      expect(picked.lightBg).toBe('0 0% 100%');
+      expect(picked.fg).toBe('240 10% 3.9%');
     });
   });
 });


### PR DESCRIPTION
## Summary

Closes #131

Splits the ~233-line `convertToSleekUi` monolith in `scripts/ingest-designs.js` into named pure helpers (MODERNIZATION_PLAN.md Task 7.6), eliminating in-place `.sort()` mutation of extracted values.

## Approach

- **`pickThemeColors(colors)`** — pure color-selection helper; darkest/lightest picks sort **fresh copies** (`[...values].sort(...)`), never mutating input
- Template builder decomposed into single-purpose builders: `buildColorTokens`, `buildTypographyTokens`, `buildSpaceTokens`, `buildTokens`, `buildFonts`, `buildAccessibility`, `buildComponentTokens`, `buildAgentInstructions`, `buildPreview`, `buildSource`
- **`convertToSleekUi`** is now a thin orchestrator (validation → parse → pick → assemble); `importedAt` injected as a parameter instead of being buried mid-literal

## Decision Record

| Field | Value |
|---|---|
| Selected option | Pure-helper extraction (balanced) |
| Alternatives considered | Minimal: only extract `pickThemeColors` (template stays >80 lines, fails AC#1) · Comprehensive: move helpers to a new module (larger blast radius, no AC benefit) |
| Rationale | Satisfies both acceptance criteria with behavior pinned by existing Task 6.2 fixture tests; keeps single-file layout consistent with prior Task 6.1 extractions |
| Complexity | medium |

## Changes

| File | Change |
|---|---|
| `scripts/ingest-designs.js` | Split monolith into 12 pure helpers; max function length 57 lines; removed in-place `.sort()` mutation |
| `tests/ingest-designs.test.js` | Added 3 purity tests for `pickThemeColors` (no-mutation snapshot, frozen-object safety, empty-palette fallbacks) |

## Test Results

```
Test Suites: 12 passed, 12 total
Tests:       122 passed, 122 total
✓ npm run validate:designs — All designs are valid
```

Task 6.2's fixture tests pass unmodified (behavior preserved).

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|---|---|---|
| No function exceeds ~80 lines; sorts operate on copies with input-mutation asserted by test | ✅ | Longest function is 57 lines; `[...values].sort()` copies; `pickThemeColors purity` tests assert non-mutation incl. frozen input |
| Task 6.2's fixture tests pass unmodified | ✅ | `tests/ingest-designs.test.js` fixture tests untouched and green |
| `npm test` passes at baseline-green pass rate | ✅ | 12 suites / 122 tests passed; `validate:designs` also green |