### PR TITLE
test(app,detail): add error/edge-path tests as latent-bug guards (#123)

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -165,3 +165,40 @@ describe('In-page anchor controls under HashRouter (#104)', () => {
     expect(document.querySelector('a[href="#catalog"]')).toBeNull();
   });
 });
+
+describe('Error/edge-path guards (#123)', () => {
+  it('recovers from an empty search via the Clear filters button', async () => {
+    render(<App />);
+    const search = screen.getByLabelText('Search by name, brand, or style...');
+    await userEvent.type(search, 'zzz-no-such-design');
+    expect(screen.getByText('No designs match your search.')).toBeInTheDocument();
+    expect(screen.getByText('0 / 1 designs')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Clear filters' }));
+    expect(screen.queryByText('No designs match your search.')).not.toBeInTheDocument();
+    expect(screen.getByText('1 / 1 designs')).toBeInTheDocument();
+    expect(search).toHaveValue('');
+  });
+
+  it('renders and toggles the theme without uncaught errors when localStorage.setItem throws', async () => {
+    localStorage.clear();
+    localStorage.setItem('sleek-ui:theme', 'light');
+    const setItem = jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('QuotaExceededError');
+    });
+
+    try {
+      render(<App />);
+      // mount effects (theme persistence, applied-design restore) must not throw
+      expect(screen.getByText(/Built solo by Luong/)).toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole('button', { name: 'Toggle theme' }));
+      expect(document.documentElement.classList.contains('dark')).toBe(true);
+      await userEvent.click(screen.getByRole('button', { name: 'Toggle theme' }));
+      expect(document.documentElement.classList.contains('dark')).toBe(false);
+      expect(setItem).toHaveBeenCalled();
+    } finally {
+      setItem.mockRestore();
+    }
+  });
+});

--- a/src/components/DesignDetail.test.tsx
+++ b/src/components/DesignDetail.test.tsx
@@ -126,3 +126,34 @@ describe('DesignDetail characterization (#117)', () => {
     ).toBeInTheDocument();
   });
 });
+
+describe('DesignDetail clipboard rejection (#123)', () => {
+  it('degrades silently when the agent-prompt copy is rejected, with no unhandled rejection', async () => {
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown) => unhandled.push(reason);
+    process.on('unhandledRejection', onUnhandled);
+
+    const writeText = jest.fn().mockRejectedValue(new Error('clipboard blocked'));
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+
+    try {
+      renderDetail('test-design');
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: 'Copy' }));
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(writeText).toHaveBeenCalledTimes(1);
+      expect(screen.queryByRole('button', { name: 'Copied!' })).not.toBeInTheDocument();
+      // page stays interactive after the rejection
+      expect(screen.getByRole('button', { name: 'Copy' })).toBeInTheDocument();
+    } finally {
+      process.removeListener('unhandledRejection', onUnhandled);
+    }
+    expect(unhandled).toEqual([]);
+  });
+});

--- a/src/components/DesignDetail.tsx
+++ b/src/components/DesignDetail.tsx
@@ -84,6 +84,8 @@ export function DesignDetail() {
     navigator.clipboard.writeText(text).then(() => {
       setIsCopied(type);
       setTimeout(() => setIsCopied(null), 2000);
+    }).catch(() => {
+      // clipboard may be blocked (permissions, insecure context); degrade silently
     });
   };
 


### PR DESCRIPTION
mise ~/.config/mise/config.toml tools: gh@2.98.0
## Summary
Resolves #123 (MODERNIZATION_PLAN Task 6.3): add regression coverage for the error/edge paths — empty-search recovery in App, blocked-storage writes across a full App render, and clipboard rejection.

## Approach
Selected the balanced option: extend the existing suites (per PR #163's characterization baseline) rather than duplicating, and fix the one unguarded path the new tests exposed.

## Decision Record
- **Options considered:** (1) minimal — tests only, leave `DesignDetail.handleCopy` unguarded; (2) balanced — edge-path tests + guard the exposed rejection; (3) comprehensive — extract a clipboard helper lib, error banners, refactor to CopyButton.
- **Selected:** Option 2. Option 1 violates acceptance criterion 2 (unguarded rejection stays); option 3 is over-scope for a test-hardening task.
- **Complexity:** medium · **Profile:** full

## Changes
| File | Change |
|------|--------|
| `src/components/DesignDetail.tsx` | Add `.catch()` to `handleCopy` so a rejecting clipboard degrades silently instead of raising an unhandled promise rejection |
| `src/App.test.tsx` | Empty-search → no-results state → 'Clear filters' recovery; full `<App />` render + theme toggle while `localStorage.setItem` throws |
| `src/components/DesignDetail.test.tsx` | Agent-prompt copy with rejecting clipboard: no confirmation state, no unhandled rejection (`unhandledRejection` listener asserted empty), page stays interactive |

## Test Results
- `npm test`: **17 suites, 154/154 passing** (was 151; +3 new tests)
- Coverage thresholds in `jest.config.cjs`: green
- `npm run validate:designs`: unaffected (no design JSON touched)

## Acceptance Criteria Verification
| Criterion | Status |
|-----------|--------|
| Tests simulate throwing storage and rejecting clipboard across App and both contexts; all pass without uncaught errors | ✅ App-level blocked-setItem render/toggle, DesignContext & ThemeContext blocked-storage (existing #103 suites extended by #163), DesignDetail prompt-copy rejection |
| Any newly exposed unguarded write/rejection is fixed inside this task | ✅ Unguarded `navigator.clipboard.writeText().then()` in `DesignDetail.handleCopy` now caught |
| `npm test` passes at ≥ the baseline-green rate | ✅ 154/154, all suites pass |

Closes #123
