### PR TITLE
fix(ui): correct accessibility interactions (ARIA, hit targets) (#139)

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -206,9 +206,9 @@ describe('Error/edge-path guards (#123)', () => {
       // mount effects (theme persistence, applied-design restore) must not throw
       expect(screen.getByText(/Built solo by Luong/)).toBeInTheDocument();
 
-      await userEvent.click(screen.getByRole('button', { name: 'Toggle theme' }));
+      await userEvent.click(screen.getByRole('button', { name: /Switch to (dark|light) theme/ }));
       expect(document.documentElement.classList.contains('dark')).toBe(true);
-      await userEvent.click(screen.getByRole('button', { name: 'Toggle theme' }));
+      await userEvent.click(screen.getByRole('button', { name: /Switch to (dark|light) theme/ }));
       expect(document.documentElement.classList.contains('dark')).toBe(false);
       expect(setItem).toHaveBeenCalled();
     } finally {

--- a/src/components/ui/CategoryFilter.tsx
+++ b/src/components/ui/CategoryFilter.tsx
@@ -24,14 +24,13 @@ export const CategoryFilter = ({
   const isAllSelected = selected === null || selected === '';
 
   return (
-    <div className={cn('flex flex-wrap items-center gap-2', className)} role="tablist" aria-label="Filter by category">
+    <div className={cn('flex flex-wrap items-center gap-2', className)} role="group" aria-label="Filter by category">
       <button
         type="button"
-        role="tab"
-        aria-selected={isAllSelected}
+        aria-pressed={isAllSelected}
         onClick={() => handleCategoryClick(null)}
         className={cn(
-          'inline-flex items-center rounded-full px-3 py-1 text-sm font-medium transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+          'inline-flex min-h-[44px] items-center rounded-full px-3 py-1 text-sm font-medium transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
           isAllSelected
             ? 'bg-primary text-primary-foreground hover:bg-primary/90'
             : 'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
@@ -50,11 +49,10 @@ export const CategoryFilter = ({
           <button
             key={category.id}
             type="button"
-            role="tab"
-            aria-selected={isSelected}
+            aria-pressed={isSelected}
             onClick={() => handleCategoryClick(isSelected ? null : category.id)}
             className={cn(
-              'inline-flex items-center rounded-full px-3 py-1 text-sm font-medium transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+              'inline-flex min-h-[44px] items-center rounded-full px-3 py-1 text-sm font-medium transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
               isSelected
                 ? 'bg-primary text-primary-foreground hover:bg-primary/90'
                 : 'border border-input bg-background hover:bg-accent hover:text-accent-foreground',

--- a/src/components/ui/CopyButton.tsx
+++ b/src/components/ui/CopyButton.tsx
@@ -18,17 +18,12 @@ export const CopyButton = ({
 }: CopyButtonProps) => {
   const { copied, error, copy } = useClipboard(true, false);
 
+  // Native button semantics already fire click for Enter/Space — a manual
+  // keydown handler here double-fires the copy on real keyboards (#139).
   const handleCopy = useCallback(async () => {
     const ok = await copy(text);
     onCopy?.(ok);
   }, [text, copy, onCopy]);
-
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault();
-      handleCopy();
-    }
-  };
 
   const getIcon = () => {
     if (error) return <AlertCircle className={cn('h-4 w-4 text-red-500', iconClassName)} />;
@@ -46,7 +41,6 @@ export const CopyButton = ({
     <button
       type="button"
       onClick={handleCopy}
-      onKeyDown={handleKeyDown}
       className={cn(
         'group relative inline-flex items-center justify-center rounded-md border border-input bg-transparent px-2 py-1.5 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
         className

--- a/src/components/ui/Header.tsx
+++ b/src/components/ui/Header.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { Menu, X } from 'lucide-react'
 import { ThemeToggle } from './ThemeToggle'
@@ -8,8 +8,47 @@ import { useTheme } from '@/context/ThemeContext'
 export function Header() {
   const { theme, toggleTheme } = useTheme()
   const [isMenuOpen, setIsMenuOpen] = useState(false)
+  const menuButtonRef = useRef<HTMLButtonElement>(null)
+  const menuRef = useRef<HTMLDivElement>(null)
 
   const closeMenu = () => setIsMenuOpen(false)
+
+  // Escape closes the menu and returns focus to the toggle; Tab is trapped
+  // between the toggle button and the open menu (#139).
+  useEffect(() => {
+    if (!isMenuOpen) return
+
+    const firstMenuItem = menuRef.current?.querySelector<HTMLElement>('a[href], button')
+    firstMenuItem?.focus()
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        setIsMenuOpen(false)
+        menuButtonRef.current?.focus()
+        return
+      }
+      if (e.key === 'Tab' && menuRef.current) {
+        const focusables = Array.from(
+          menuRef.current.querySelectorAll<HTMLElement>('a[href], button'),
+        )
+        if (focusables.length === 0) return
+        const first = focusables[0]
+        const last = focusables[focusables.length - 1]
+        const active = document.activeElement
+        if (e.shiftKey && (active === first || !menuRef.current.contains(active))) {
+          e.preventDefault()
+          menuButtonRef.current?.focus()
+        } else if (!e.shiftKey && active === last) {
+          e.preventDefault()
+          first.focus()
+        }
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [isMenuOpen])
 
   const navLinkClass = "text-sm font-medium text-foreground hover:text-brand transition-colors"
   const navLinkMutedClass = "text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
@@ -47,6 +86,7 @@ export function Header() {
 
           {/* Mobile Menu Button */}
           <button
+            ref={menuButtonRef}
             onClick={() => setIsMenuOpen(!isMenuOpen)}
             className="md:hidden inline-flex h-9 w-9 items-center justify-center rounded-md border border-border text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
             aria-label={isMenuOpen ? 'Close menu' : 'Open menu'}
@@ -59,7 +99,7 @@ export function Header() {
 
       {/* Mobile Navigation */}
       {isMenuOpen && (
-        <div className="md:hidden border-t bg-background/95 backdrop-blur">
+        <div ref={menuRef} className="md:hidden border-t bg-background/95 backdrop-blur">
           <nav className="container mx-auto flex flex-col px-4 py-4 gap-1">
             <Link
               to="/"

--- a/src/components/ui/SearchBar.tsx
+++ b/src/components/ui/SearchBar.tsx
@@ -56,7 +56,7 @@ export const SearchBar = ({
           type="button"
           onClick={handleClear}
           className={cn(
-            'absolute inset-y-0 right-0 flex items-center pr-3 text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+            'absolute right-0 top-1/2 flex h-11 w-11 -translate-y-1/2 items-center justify-center text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
             clearButtonClassName
           )}
           aria-label="Clear search"

--- a/src/components/ui/ThemeToggle.tsx
+++ b/src/components/ui/ThemeToggle.tsx
@@ -9,7 +9,13 @@ interface ThemeToggleProps {
 
 export function ThemeToggle({ theme, onToggle }: ThemeToggleProps) {
   return (
-    <Button variant="ghost" size="icon" onClick={onToggle} aria-label="Toggle theme">
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={onToggle}
+      aria-pressed={theme === 'dark'}
+      aria-label={theme === 'light' ? 'Switch to dark theme' : 'Switch to light theme'}
+    >
       {theme === 'light' ? (
         <Moon className="h-5 w-5" />
       ) : (

--- a/src/components/ui/__tests__/CategoryFilter.test.tsx
+++ b/src/components/ui/__tests__/CategoryFilter.test.tsx
@@ -16,44 +16,60 @@ function renderFilter(selected: string | null = null, onChange = jest.fn()) {
 describe('CategoryFilter (#120)', () => {
   it('shows the aggregate count on the All pill', () => {
     renderFilter();
-    expect(screen.getByRole('tab', { name: /All/ })).toHaveTextContent('7');
+    expect(screen.getByRole('button', { name: /All/ })).toHaveTextContent('7');
   });
 
   it('toggles an already-selected category back off to All', () => {
     const onChange = renderFilter('minimal');
-    fireEvent.click(screen.getByRole('tab', { name: /Minimal/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Minimal/ }));
     expect(onChange).toHaveBeenLastCalledWith(null);
   });
 
   it('selects All when its pill is clicked', () => {
     const onChange = renderFilter('dark');
-    fireEvent.click(screen.getByRole('tab', { name: /^All/ }));
+    fireEvent.click(screen.getByRole('button', { name: /^All/ }));
     expect(onChange).toHaveBeenLastCalledWith(null);
   });
 
-  it('marks exactly one tab as aria-selected based on the selected prop', () => {
+  it('uses a group of toggle buttons instead of tab semantics (#139)', () => {
+    renderFilter();
+    expect(screen.getByRole('group', { name: 'Filter by category' })).toBeInTheDocument();
+    expect(screen.queryByRole('tablist')).toBeNull();
+    expect(screen.queryAllByRole('tab')).toHaveLength(0);
+  });
+
+  it('marks exactly one pill as aria-pressed based on the selected prop (#139)', () => {
     const { rerender } = render(
       <CategoryFilter categories={categories} selected={null} onChange={() => {}} />,
     );
-    expect(screen.getByRole('tab', { name: /^All/ })).toHaveAttribute(
-      'aria-selected',
+    expect(screen.getByRole('button', { name: /^All/ })).toHaveAttribute(
+      'aria-pressed',
       'true',
     );
-    expect(screen.getByRole('tab', { name: /Minimal/ })).toHaveAttribute(
-      'aria-selected',
+    expect(screen.getByRole('button', { name: /Minimal/ })).toHaveAttribute(
+      'aria-pressed',
       'false',
     );
 
     rerender(
       <CategoryFilter categories={categories} selected="dark" onChange={() => {}} />,
     );
-    expect(screen.getByRole('tab', { name: /Dark/ })).toHaveAttribute(
-      'aria-selected',
+    expect(screen.getByRole('button', { name: /Dark/ })).toHaveAttribute(
+      'aria-pressed',
       'true',
     );
-    expect(screen.getByRole('tab', { name: /^All/ })).toHaveAttribute(
-      'aria-selected',
+    expect(screen.getByRole('button', { name: /^All/ })).toHaveAttribute(
+      'aria-pressed',
       'false',
     );
+  });
+
+  it('pills meet the 44px minimum hit area (#139)', () => {
+    renderFilter();
+    const pills = screen.getAllByRole('button');
+    expect(pills.length).toBeGreaterThanOrEqual(3);
+    for (const pill of pills) {
+      expect(pill).toHaveClass('min-h-[44px]');
+    }
   });
 });

--- a/src/components/ui/__tests__/CopyButton.test.tsx
+++ b/src/components/ui/__tests__/CopyButton.test.tsx
@@ -51,13 +51,16 @@ describe('CopyButton (#120)', () => {
     ).toBeInTheDocument();
   });
 
-  it('copies via keyboard Enter activation', async () => {
+  it('writes the clipboard exactly once for Enter-key activation (#139)', async () => {
     const writeText = mockClipboard(() => Promise.resolve());
     render(<CopyButton text="hello" />);
     const button = screen.getByRole('button', { name: 'Copy to clipboard' });
     fireEvent.keyDown(button, { key: 'Enter' });
-    await Promise.resolve();
-    expect(writeText).toHaveBeenCalledWith('hello');
+    expect(writeText).not.toHaveBeenCalled();
+    // Browsers fire a native click after Enter keydown on buttons — the copy
+    // must run exactly once across both events.
+    await clickAsync(button);
+    expect(writeText).toHaveBeenCalledTimes(1);
   });
 
   it('does not update state after unmount mid-feedback (#132)', async () => {

--- a/src/components/ui/__tests__/Header.test.tsx
+++ b/src/components/ui/__tests__/Header.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { ThemeProvider } from '@/context/ThemeContext';
+import { Header } from '../Header';
+
+function renderHeader() {
+  return render(
+    <MemoryRouter>
+      <ThemeProvider>
+        <Header />
+      </ThemeProvider>
+    </MemoryRouter>,
+  );
+}
+
+function openMenu() {
+  fireEvent.click(screen.getByRole('button', { name: /Open menu/i }));
+}
+
+function firstMenuLink() {
+  return document.querySelector<HTMLAnchorElement>('div.border-t nav a[href="/"]')!;
+}
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  });
+});
+
+describe('Header mobile menu (#139)', () => {
+  it('closes on Escape and moves focus back to the toggle button', () => {
+    renderHeader();
+    const toggle = screen.getByRole('button', { name: /Open menu/i });
+    openMenu();
+    expect(screen.getByRole('button', { name: /Close menu/i })).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(screen.queryByRole('button', { name: /Close menu/i })).toBeNull();
+    expect(document.activeElement).toBe(toggle);
+  });
+
+  it('moves focus into the menu when opened', () => {
+    renderHeader();
+    openMenu();
+    expect(document.activeElement).toBe(firstMenuLink());
+  });
+
+  it('wraps Tab from the last menu item back to the first', () => {
+    renderHeader();
+    openMenu();
+    const browse = screen.getByRole('button', { name: 'Browse Designs' });
+    browse.focus();
+
+    fireEvent.keyDown(document, { key: 'Tab' });
+
+    expect(document.activeElement).toBe(firstMenuLink());
+  });
+});

--- a/src/components/ui/__tests__/SearchBar.test.tsx
+++ b/src/components/ui/__tests__/SearchBar.test.tsx
@@ -31,4 +31,10 @@ describe('SearchBar (#120)', () => {
     fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Escape' });
     expect(onChange).toHaveBeenLastCalledWith('');
   });
+
+  it('clear button meets the 44px minimum hit area (#139)', () => {
+    render(<SearchBar value="dark" onChange={() => {}} />);
+    const clear = screen.getByRole('button', { name: 'Clear search' });
+    expect(clear).toHaveClass('h-11', 'w-11');
+  });
 });

--- a/src/components/ui/__tests__/ThemeToggle.test.tsx
+++ b/src/components/ui/__tests__/ThemeToggle.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ThemeToggle } from '../ThemeToggle';
+
+describe('ThemeToggle (#139)', () => {
+  it('announces the target state in its label when light', () => {
+    const onToggle = jest.fn();
+    render(<ThemeToggle theme="light" onToggle={onToggle} />);
+    const button = screen.getByRole('button', { name: 'Switch to dark theme' });
+    expect(button).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('announces the target state in its label and aria-pressed when dark', () => {
+    const onToggle = jest.fn();
+    render(<ThemeToggle theme="dark" onToggle={onToggle} />);
+    const button = screen.getByRole('button', { name: 'Switch to light theme' });
+    expect(button).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('fires onToggle on click', () => {
+    const onToggle = jest.fn();
+    render(<ThemeToggle theme="light" onToggle={onToggle} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Switch to dark theme' }));
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the hand-rolled ARIA/keyboard behavior batch from #139 (MODERNIZATION_PLAN Task 8.5):

- **CopyButton double-fire**: removed the manual Enter/Space `keydown` handler — native button semantics already fire `click`, so the handler caused two clipboard writes per keypress.
- **CategoryFilter semantics**: replaced the invalid `role="tablist"`/`role="tab"` (no tabpanels) with a `role="group"` of toggle buttons exposing `aria-pressed`.
- **Hit targets**: CategoryFilter pills and the SearchBar clear icon now meet the ≥44px minimum.
- **Toggle state**: ThemeToggle now announces its target state via a dynamic `aria-label` plus `aria-pressed` (the TokenTable preview toggle already had `aria-pressed`).
- **Mobile menu**: Escape closes it and returns focus to the toggle; focus moves into the menu on open; Tab is trapped between the toggle and open menu.

Closes #139

## Approach

Minimal, per-control fixes with no behavior changes beyond accessibility. The CopyButton keyboard test now simulates the browser's keydown→click activation sequence and asserts exactly one clipboard write. Hit-area assertions check the enforced Tailwind min-size classes (`min-h-[44px]`, `h-11 w-11`) since jsdom applies no stylesheets.

## Decision Record

- **Selected option** (balanced): fix each control in place; no new abstractions or focus-trap dependency. Rejected: radiogroup conversion for CategoryFilter (larger behavioral change, multi-select semantics don't fit), external focus-trap library (overkill for a 3-item menu).

## Changes

| File | Change |
|------|--------|
| `src/components/ui/CopyButton.tsx` | Removed manual keydown copy handler |
| `src/components/ui/CategoryFilter.tsx` | `tablist/tab` → `group` + `aria-pressed`; 44px pill hit area |
| `src/components/ui/SearchBar.tsx` | Clear button resized to 44×44 centered hit area |
| `src/components/ui/ThemeToggle.tsx` | Stateful label + `aria-pressed` |
| `src/components/ui/Header.tsx` | Escape-to-close, focus restore, initial focus, Tab trap |
| tests | Updated 3 suites; added `ThemeToggle.test.tsx`, `Header.test.tsx` |

## Test Results

- Full suite: **22 suites, 181/181 passed**
- `npm run build`: green; typecheck clean
- New/updated assertions cover all three acceptance criteria: single clipboard write on Enter, `aria-pressed` filter controls + Escape/focus behavior, and ≥44px hit areas.

## Acceptance Criteria Verification

| Criterion | Status |
|-----------|--------|
| Single clipboard write on Enter keypress; filter controls expose `aria-pressed`; Escape closes mobile menu and focus moves out | ✅ `CopyButton.test.tsx`, `CategoryFilter.test.tsx`, `Header.test.tsx` |
| Pills/clear button meet ≥44px hit area | ✅ asserted via enforced size classes in `CategoryFilter.test.tsx` / `SearchBar.test.tsx` |
| `npm test` passes at baseline-green | ✅ 181/181 |