### PR TITLE
fix(catalog): reconcile release records and fix missing thumbnails (#143)

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,17 +1,13 @@
-# Release v1.0.0
+# Release Notes
 
-## 2026-03-27
+Release notes for sleek-ui live in [docs/CHANGELOG.md](docs/CHANGELOG.md) — the
+single authoritative record for every version. This file is only a pointer and
+must not duplicate changelog entries.
 
-### Phase 2 Release - Full MVP Launch
+## Latest release
 
-This release marks the Phase 2 (Full MVP Launch) of sleek-ui.
+- **v1.0.0** — Phase 2, Full MVP Launch (2026-03-27). See
+  [docs/CHANGELOG.md](docs/CHANGELOG.md).
 
-### Changes
-
-- Version: 1.0.0
-- Git tag: v1.0.0 pushed
-- GitHub Release created
-
-### Design Files
-
-- Editorial Dark - https://luongnv.com/sleek-ui/designs/editorial-dark.json
+Ongoing changes are tracked under **[Unreleased]** in the changelog until the
+next version is tagged.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,26 +1,40 @@
 # Changelog
 
-All notable changes to sleek-ui are documented here.
+All notable changes to sleek-ui are documented here. This is the single
+authoritative release record — `RELEASE.md` cross-links here and must not
+duplicate entries.
 
-## [1.0.0] — 2026-04-02
+## [Unreleased]
+
+### Added
+- 60-design catalog: 5 original hand-crafted systems, 54 brand-inspired design
+  systems (Airbnb, Apple, Stripe, Vercel, and more), and a glassmorphic system
+- Generated SVG thumbnails for every catalog design
+  (`scripts/generate-thumbnails.js`) — zero thumbnail 404s
+- Design-extractor agent skill for extracting new design systems from URLs or
+  screenshots
+- `ThemeContext` — apply any design system live to the catalog via CSS variable
+  injection; `AppliedDesignBanner` persistent active-design bar with reset
+- `LogoMark` SVG component (inline, `currentColor`)
+
+### Changed
+- Landing page improved with StoryBrand narrative, responsive mobile nav, and
+  design polish
+- Single-source catalog registry with testable design transform
+- Deploy pipeline gated on lint, typecheck, tests, and design validation
+- Bundle performance: lazy-loaded design data and route splitting
+- License updated from ISC to Apache 2.0; `package.json` metadata expanded
+- Migrated domain from `luongnv89.github.io/sleek-ui` to `luongnv.com/sleek-ui`
+
+## [1.0.0] — 2026-03-27
+
+Phase 2 — Full MVP Launch. Tag: `v1.0.0`, GitHub Release created.
 
 ### Added
 - Full landing page redesign with AIDA copywriting framework
 - Hero section with grid background, green glow, and agent compatibility badges
 - "How it works" 3-step section with copy-ready agent prompt block
-- `ThemeContext` — apply any design system live to the catalog via CSS variable injection
-- `AppliedDesignBanner` — persistent bottom bar showing active design with reset button
-- `LogoMark` SVG component (inline, `currentColor`)
-- 54 brand-inspired design systems (Airbnb, Apple, Stripe, Vercel, and more)
 - Promotional video on landing page
-- 4-column catalog grid with improved empty state and "Clear filters" button
-- Sticky header with smooth-scroll navigation
-- Footer with GitHub and Brand Showcase links
-- Migrated domain from `luongnv89.github.io/sleek-ui` to `luongnv.com/sleek-ui`
-
-### Changed
-- License updated from ISC to Apache 2.0
-- `package.json` — added description, keywords, author
 
 ## [0.1.0] — 2024
 
@@ -30,3 +44,7 @@ All notable changes to sleek-ui are documented here.
 - GitHub Pages deployment via GitHub Actions
 - Schema validation script
 - Agent prompt template
+
+[Unreleased]: https://github.com/luongnv89/sleek-ui/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/luongnv89/sleek-ui/releases/tag/v1.0.0
+[0.1.0]: https://github.com/luongnv89/sleek-ui/releases/tag/v0.1.0

--- a/public/previews/airbnb-thumb.svg
+++ b/public/previews/airbnb-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(0, 0%, 100%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(0, 0%, 13%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">airbnb</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(349, 100%, 61%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(0, 0%, 100%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/public/previews/airtable-thumb.svg
+++ b/public/previews/airtable-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(0, 0%, 100%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(240, 10%, 3.9%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">airtable</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(120, 100%, 20%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(0, 0%, 100%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/public/previews/apple-thumb.svg
+++ b/public/previews/apple-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(0, 0%, 100%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(240, 3%, 12%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">apple</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(210, 100%, 45%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(0, 0%, 100%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/public/previews/bmw-thumb.svg
+++ b/public/previews/bmw-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(0, 0%, 100%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(0, 0%, 15%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">bmw</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(215, 77%, 47%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(0, 0%, 100%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/public/previews/cal-thumb.svg
+++ b/public/previews/cal-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(0, 0%, 100%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(240, 10%, 3.9%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">cal</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(204, 100%, 50%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(0, 0%, 100%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/public/previews/claude-thumb.svg
+++ b/public/previews/claude-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(0, 0%, 100%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(60, 3%, 8%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">claude</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(15, 56%, 52%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(0, 0%, 100%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/public/previews/clay-thumb.svg
+++ b/public/previews/clay-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(0, 0%, 100%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(240, 10%, 3.9%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">clay</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(213, 99%, 28%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(0, 0%, 100%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/public/previews/clickhouse-thumb.svg
+++ b/public/previews/clickhouse-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(0, 0%, 100%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(0, 0%, 8%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">clickhouse</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(143, 64%, 24%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(0, 0%, 100%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/public/previews/cohere-thumb.svg
+++ b/public/previews/cohere-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(0, 0%, 100%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(0, 0%, 13%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">cohere</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(217, 80%, 48%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(0, 0%, 100%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/public/previews/coinbase-thumb.svg
+++ b/public/previews/coinbase-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(0, 0%, 100%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(220, 13%, 5%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">coinbase</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(221, 100%, 50%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(0, 0%, 100%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/public/previews/composio-thumb.svg
+++ b/public/previews/composio-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(0, 0%, 100%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(240, 10%, 3.9%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">composio</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(238, 100%, 40%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(0, 0%, 100%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/public/previews/cursor-thumb.svg
+++ b/public/previews/cursor-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(0, 0%, 100%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(240, 10%, 3.9%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">cursor</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(19, 100%, 48%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(0, 0%, 100%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/public/previews/deep-ocean-thumb.svg
+++ b/public/previews/deep-ocean-thumb.svg
@@ -1,12 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
-  <rect width="400" height="300" fill="#fff"/>
-  <text x="200" y="50" text-anchor="middle" fill="#1a1412" font-family="Plus Jakarta Sans, sans-serif" font-size="20" font-weight="600">Warm SaaS</text>
-  <rect x="40" y="70" width="100" height="60" rx="8" fill="#ffedd5" stroke="#fed7aa" stroke-width="1"/>
-  <rect x="160" y="70" width="100" height="60" rx="8" fill="#f97316"/>
-  <rect x="280" y="70" width="80" height="60" rx="8" fill="#22c55e"/>
-  <rect x="40" y="150" width="320" height="100" rx="8" fill="#fff7ed" stroke="#fed7aa" stroke-width="1"/>
-  <rect x="60" y="170" width="80" height="30" rx="4" fill="#f97316"/>
-  <rect x="160" y="170" width="80" height="30" rx="4" fill="#22c55e"/>
-  <rect x="260" y="170" width="80" height="30" rx="4" fill="#3b82f6"/>
-  <text x="200" y="280" text-anchor="middle" fill="#666" font-family="Plus Jakarta Sans, sans-serif" font-size="12">Thumbnail</text>
+  <rect width="400" height="300" fill="hsl(220, 40%, 8%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(185, 80%, 75%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">deep-ocean</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(220, 15%, 65%)" font-family="Inter, sans-serif" font-size="12">Dark Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(185, 80%, 55%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(220, 40%, 8%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
 </svg>

--- a/public/previews/elevenlabs-thumb.svg
+++ b/public/previews/elevenlabs-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(0, 0%, 100%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(240, 10%, 3.9%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">elevenlabs</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(0, 0%, 100%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(0, 0%, 100%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/public/previews/expo-thumb.svg
+++ b/public/previews/expo-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(0, 0%, 100%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(210, 13%, 13%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">expo</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(228, 100%, 64%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(0, 0%, 100%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/public/previews/figma-thumb.svg
+++ b/public/previews/figma-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(0, 0%, 100%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(240, 10%, 3.9%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">figma</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(0, 0%, 0%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(0, 0%, 100%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/public/previews/framer-thumb.svg
+++ b/public/previews/framer-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(0, 0%, 100%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(0, 0%, 4%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">framer</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(204, 100%, 50%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(0, 0%, 100%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/public/previews/hashicorp-thumb.svg
+++ b/public/previews/hashicorp-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(240, 7%, 94%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(228, 16%, 6%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">hashicorp</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(274, 85%, 52%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(240, 7%, 94%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/public/previews/ibm-thumb.svg
+++ b/public/previews/ibm-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(0, 0%, 100%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(240, 10%, 3.9%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">ibm</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(137, 63%, 39%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(0, 0%, 100%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/public/previews/intercom-thumb.svg
+++ b/public/previews/intercom-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(0, 0%, 100%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(240, 10%, 3.9%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">intercom</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(140, 91%, 46%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(0, 0%, 100%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/public/previews/kraken-thumb.svg
+++ b/public/previews/kraken-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(0, 0%, 100%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(225, 11%, 7%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">kraken</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(153, 78%, 35%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(0, 0%, 100%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/public/previews/linear.app-thumb.svg
+++ b/public/previews/linear.app-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(0, 0%, 100%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(180, 7%, 97%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">linear.app</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(234, 56%, 60%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(0, 0%, 100%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/public/previews/lovable-thumb.svg
+++ b/public/previews/lovable-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(45, 40%, 98%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(240, 10%, 3.9%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">lovable</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(42, 38%, 95%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(45, 40%, 98%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/public/previews/minimax-thumb.svg
+++ b/public/previews/minimax-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(0, 0%, 100%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(0, 0%, 13%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">minimax</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(222, 88%, 51%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(0, 0%, 100%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/public/previews/mintlify-thumb.svg
+++ b/public/previews/mintlify-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(0, 0%, 100%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(0, 0%, 5%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">mintlify</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(158, 81%, 49%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(0, 0%, 100%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/public/previews/miro-thumb.svg
+++ b/public/previews/miro-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(0, 0%, 100%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(240, 3%, 11%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">miro</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(0, 83%, 91%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(0, 0%, 100%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/public/previews/mistral.ai-thumb.svg
+++ b/public/previews/mistral.ai-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(0, 0%, 100%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(240, 10%, 3.9%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">mistral.ai</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(17, 96%, 52%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(0, 0%, 100%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/public/previews/mongodb-thumb.svg
+++ b/public/previews/mongodb-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(0, 0%, 100%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(240, 10%, 3.9%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">mongodb</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(145, 100%, 46%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(0, 0%, 100%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/public/previews/notion-thumb.svg
+++ b/public/previews/notion-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(0, 0%, 100%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(240, 10%, 3.9%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">notion</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(133, 74%, 39%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(0, 0%, 100%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/public/previews/nvidia-thumb.svg
+++ b/public/previews/nvidia-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(0, 0%, 100%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(0, 0%, 10%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">nvidia</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(82, 100%, 36%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(0, 0%, 100%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/public/previews/ollama-thumb.svg
+++ b/public/previews/ollama-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(0, 0%, 100%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(0, 0%, 15%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">ollama</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(0, 0%, 0%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(0, 0%, 100%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/public/previews/opencode.ai-thumb.svg
+++ b/public/previews/opencode.ai-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(0, 10%, 94%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(240, 10%, 3.9%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">opencode.ai</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(211, 100%, 50%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(0, 10%, 94%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/public/previews/pinterest-thumb.svg
+++ b/public/previews/pinterest-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(0, 0%, 100%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(240, 10%, 3.9%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">pinterest</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(149, 58%, 15%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(0, 0%, 100%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/public/previews/posthog-thumb.svg
+++ b/public/previews/posthog-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(0, 0%, 96%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(240, 10%, 3.9%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">posthog</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(217, 91%, 60%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(0, 0%, 96%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/public/previews/raycast-thumb.svg
+++ b/public/previews/raycast-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(0, 0%, 100%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(210, 4%, 10%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">raycast</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(220, 18%, 3%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(0, 0%, 100%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/public/previews/replicate-thumb.svg
+++ b/public/previews/replicate-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(0, 0%, 100%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(240, 10%, 3.9%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">replicate</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(152, 56%, 39%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(0, 0%, 100%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/public/previews/resend-thumb.svg
+++ b/public/previews/resend-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(0, 0%, 94%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(240, 10%, 3.9%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">resend</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(220, 100%, 99%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(0, 0%, 94%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/public/previews/revolut-thumb.svg
+++ b/public/previews/revolut-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(0, 0%, 100%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(240, 10%, 3.9%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">revolut</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(97, 69%, 31%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(0, 0%, 100%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/public/previews/runwayml-thumb.svg
+++ b/public/previews/runwayml-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(0, 0%, 100%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(240, 10%, 3.9%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">runwayml</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(0, 0%, 0%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(0, 0%, 100%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/public/previews/sanity-thumb.svg
+++ b/public/previews/sanity-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(0, 0%, 100%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(0, 0%, 4%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">sanity</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(151, 60%, 51%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(0, 0%, 100%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/public/previews/sentry-thumb.svg
+++ b/public/previews/sentry-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(0, 0%, 100%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(240, 10%, 3.9%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">sentry</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(77, 83%, 62%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(0, 0%, 100%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/public/previews/spacex-thumb.svg
+++ b/public/previews/spacex-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(240, 50%, 96%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(240, 10%, 3.9%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">spacex</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(0, 0%, 0%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(240, 50%, 96%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/public/previews/spotify-thumb.svg
+++ b/public/previews/spotify-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(0, 0%, 100%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(0, 0%, 7%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">spotify</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(141, 76%, 48%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(0, 0%, 100%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/public/previews/stripe-thumb.svg
+++ b/public/previews/stripe-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(0, 0%, 100%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(211, 78%, 11%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">stripe</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(238, 50%, 22%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(0, 0%, 100%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/public/previews/supabase-thumb.svg
+++ b/public/previews/supabase-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(0, 0%, 94%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(0, 0%, 6%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">supabase</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(153, 60%, 53%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(0, 0%, 94%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/public/previews/superhuman-thumb.svg
+++ b/public/previews/superhuman-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(0, 0%, 100%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(240, 10%, 3.9%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">superhuman</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(244, 38%, 16%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(0, 0%, 100%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/public/previews/swiss-clean-thumb.svg
+++ b/public/previews/swiss-clean-thumb.svg
@@ -1,12 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
-  <rect width="400" height="300" fill="#fff"/>
-  <text x="200" y="50" text-anchor="middle" fill="#1a1412" font-family="Plus Jakarta Sans, sans-serif" font-size="20" font-weight="600">Warm SaaS</text>
-  <rect x="40" y="70" width="100" height="60" rx="8" fill="#ffedd5" stroke="#fed7aa" stroke-width="1"/>
-  <rect x="160" y="70" width="100" height="60" rx="8" fill="#f97316"/>
-  <rect x="280" y="70" width="80" height="60" rx="8" fill="#22c55e"/>
-  <rect x="40" y="150" width="320" height="100" rx="8" fill="#fff7ed" stroke="#fed7aa" stroke-width="1"/>
-  <rect x="60" y="170" width="80" height="30" rx="4" fill="#f97316"/>
-  <rect x="160" y="170" width="80" height="30" rx="4" fill="#22c55e"/>
-  <rect x="260" y="170" width="80" height="30" rx="4" fill="#3b82f6"/>
-  <text x="200" y="280" text-anchor="middle" fill="#666" font-family="Plus Jakarta Sans, sans-serif" font-size="12">Thumbnail</text>
+  <rect width="400" height="300" fill="hsl(0, 0%, 100%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(0, 0%, 15%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">swiss-clean</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(0, 0%, 45%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(0, 72%, 51%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(0, 0%, 100%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
 </svg>

--- a/public/previews/together.ai-thumb.svg
+++ b/public/previews/together.ai-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(0, 0%, 100%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(240, 10%, 3.9%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">together.ai</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(314, 86%, 55%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(0, 0%, 100%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/public/previews/uber-thumb.svg
+++ b/public/previews/uber-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(0, 0%, 100%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(0, 0%, 29%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">uber</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(240, 100%, 47%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(0, 0%, 100%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/public/previews/vercel-thumb.svg
+++ b/public/previews/vercel-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(0, 0%, 100%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(240, 10%, 3.9%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">vercel</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(4, 100%, 65%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(0, 0%, 100%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/public/previews/voltagent-thumb.svg
+++ b/public/previews/voltagent-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(0, 0%, 95%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(240, 10%, 3.9%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">voltagent</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(217, 62%, 50%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(0, 0%, 95%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/public/previews/warp-thumb.svg
+++ b/public/previews/warp-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(45, 29%, 97%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(240, 10%, 3.9%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">warp</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(264, 2%, 40%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(45, 29%, 97%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/public/previews/webflow-thumb.svg
+++ b/public/previews/webflow-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(0, 0%, 85%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(0, 0%, 3%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">webflow</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(129, 100%, 42%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(0, 0%, 85%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/public/previews/wise-thumb.svg
+++ b/public/previews/wise-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(96, 11%, 91%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(80, 11%, 5%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">wise</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(97, 72%, 67%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(96, 11%, 91%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/public/previews/x.ai-thumb.svg
+++ b/public/previews/x.ai-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(0, 0%, 100%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(240, 10%, 3.9%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">x.ai</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(0, 0%, 100%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(0, 0%, 100%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/public/previews/zapier-thumb.svg
+++ b/public/previews/zapier-thumb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="hsl(45, 100%, 99%)"/>
+  <text x="200" y="130" text-anchor="middle" fill="hsl(240, 10%, 3.9%)" font-family="Inter, sans-serif" font-size="18" font-weight="600">zapier</text>
+  <text x="200" y="160" text-anchor="middle" fill="hsl(240, 3.8%, 46.1%)" font-family="Inter, sans-serif" font-size="12">Light Mode Preview</text>
+  <rect x="100" y="180" width="200" height="40" rx="6" fill="hsl(19, 100%, 50%)"/>
+  <text x="200" y="205" text-anchor="middle" fill="hsl(45, 100%, 99%)" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>
+</svg>

--- a/scripts/generate-thumbnails.js
+++ b/scripts/generate-thumbnails.js
@@ -20,13 +20,14 @@ const PREVIEWS_DIR = path.join(__dirname, '..', 'public', 'previews');
 const force = process.argv.includes('--force');
 
 const cssColor = (value, fallback) => {
+  const neutralize = (s) => s.replace(/["'<>&]/g, '');
   if (!value || typeof value !== 'string') return fallback;
   const v = value.trim();
   // Tailwind-style HSL triplet, e.g. "349 100% 61%"
   if (/^[\d.]+\s+[\d.]+%\s+[\d.]+%$/.test(v)) {
     return `hsl(${v.split(/\s+/).join(', ')})`;
   }
-  return v;
+  return neutralize(v);
 };
 
 const esc = (s) =>

--- a/scripts/generate-thumbnails.js
+++ b/scripts/generate-thumbnails.js
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+/**
+ * Generate thumbnail SVGs for catalog designs.
+ *
+ * For every public/designs/{slug}.json without a matching
+ * public/previews/{slug}-thumb.svg, renders a branded 400x300 SVG using the
+ * design's own palette (background, foreground, primary, secondary).
+ *
+ * Usage:
+ *   node scripts/generate-thumbnails.js           # generate missing thumbs only
+ *   node scripts/generate-thumbnails.js --force   # regenerate all thumbs
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const DESIGNS_DIR = path.join(__dirname, '..', 'public', 'designs');
+const PREVIEWS_DIR = path.join(__dirname, '..', 'public', 'previews');
+
+const force = process.argv.includes('--force');
+
+const cssColor = (value, fallback) => {
+  if (!value || typeof value !== 'string') return fallback;
+  const v = value.trim();
+  // Tailwind-style HSL triplet, e.g. "349 100% 61%"
+  if (/^[\d.]+\s+[\d.]+%\s+[\d.]+%$/.test(v)) {
+    return `hsl(${v.split(/\s+/).join(', ')})`;
+  }
+  return v;
+};
+
+const esc = (s) =>
+  s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+function renderSvg({ name, modeLabel, bg, fg, muted, primary }) {
+  return [
+    '<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">',
+    `  <rect width="400" height="300" fill="${bg}"/>`,
+    `  <text x="200" y="130" text-anchor="middle" fill="${fg}" font-family="Inter, sans-serif" font-size="18" font-weight="600">${esc(name)}</text>`,
+    `  <text x="200" y="160" text-anchor="middle" fill="${muted}" font-family="Inter, sans-serif" font-size="12">${esc(modeLabel)} Preview</text>`,
+    `  <rect x="100" y="180" width="200" height="40" rx="6" fill="${primary}"/>`,
+    `  <text x="200" y="205" text-anchor="middle" fill="${bg}" font-family="Inter, sans-serif" font-size="14">Thumbnail</text>`,
+    '</svg>',
+    '',
+  ].join('\n');
+}
+
+function main() {
+  fs.mkdirSync(PREVIEWS_DIR, { recursive: true });
+
+  const files = fs
+    .readdirSync(DESIGNS_DIR)
+    .filter((f) => f.endsWith('.json'))
+    .sort();
+
+  let created = 0;
+  let skipped = 0;
+
+  for (const file of files) {
+    const slug = file.replace(/\.json$/, '');
+    const outPath = path.join(PREVIEWS_DIR, `${slug}-thumb.svg`);
+
+    if (!force && fs.existsSync(outPath)) {
+      skipped++;
+      continue;
+    }
+
+    const design = JSON.parse(
+      fs.readFileSync(path.join(DESIGNS_DIR, file), 'utf8')
+    );
+    const mode = design.defaultMode || 'light';
+    const modeColors =
+      design.tokens?.colors?.[mode] || design.tokens?.colors?.light || {};
+
+    const svg = renderSvg({
+      name: design.name || slug,
+      modeLabel: mode === 'dark' ? 'Dark Mode' : 'Light Mode',
+      bg: cssColor(modeColors.background, '#ffffff'),
+      fg: cssColor(modeColors.foreground, '#111111'),
+      muted: cssColor(modeColors['muted-foreground'], cssColor(modeColors.muted, '#888888')),
+      primary: cssColor(modeColors.primary, '#4f46e5'),
+    });
+
+    fs.writeFileSync(outPath, svg);
+    created++;
+  }
+
+  console.log(
+    `thumbnails: ${created} generated, ${skipped} skipped (${files.length} designs total)`
+  );
+}
+
+main();

--- a/tests/thumbnails.test.js
+++ b/tests/thumbnails.test.js
@@ -1,0 +1,74 @@
+/**
+ * Regression guard for issue #143.
+ *
+ * Every catalog design must reference a thumbnail that actually ships in
+ * public/previews/ — otherwise catalog cards render 404 images in production.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const DESIGNS_DIR = path.join(ROOT, 'public', 'designs');
+const PREVIEWS_DIR = path.join(ROOT, 'public', 'previews');
+
+const listDesignSlugs = () =>
+  fs
+    .readdirSync(DESIGNS_DIR)
+    .filter((f) => f.endsWith('.json'))
+    .map((f) => f.replace(/\.json$/, ''))
+    .sort();
+
+describe('catalog thumbnails (#143)', () => {
+  const slugs = listDesignSlugs();
+
+  it('has a catalog to validate', () => {
+    expect(slugs.length).toBeGreaterThanOrEqual(60);
+  });
+
+  it.each(slugs)('%s resolves its preview.thumbnail to an existing file', (slug) => {
+    const design = JSON.parse(
+      fs.readFileSync(path.join(DESIGNS_DIR, `${slug}.json`), 'utf8')
+    );
+    const thumbnail = design.preview?.thumbnail;
+
+    expect(typeof thumbnail).toBe('string');
+    expect(thumbnail).toMatch(/^\/previews\//);
+
+    const onDisk = path.join(ROOT, 'public', thumbnail.replace(/^\//, ''));
+    expect(fs.existsSync(onDisk)).toBe(true);
+  });
+
+  it('ships one thumb SVG per design slug', () => {
+    for (const slug of slugs) {
+      const thumbPath = path.join(PREVIEWS_DIR, `${slug}-thumb.svg`);
+      expect(fs.existsSync(thumbPath)).toBe(true);
+    }
+  });
+});
+
+describe('release records (#143)', () => {
+  const changelog = fs.readFileSync(
+    path.join(ROOT, 'docs', 'CHANGELOG.md'),
+    'utf8'
+  );
+  const release = fs.readFileSync(path.join(ROOT, 'RELEASE.md'), 'utf8');
+
+  it('keeps docs/CHANGELOG.md as the single authoritative history', () => {
+    const versionHeaders = changelog.match(/^## \[[^\]]+\]/gm) || [];
+    const seen = new Set();
+    for (const header of versionHeaders) {
+      expect(seen.has(header)).toBe(false);
+      seen.add(header);
+    }
+    expect(versionHeaders.length).toBeGreaterThan(0);
+  });
+
+  it('cross-links RELEASE.md to the changelog instead of duplicating records', () => {
+    expect(release).toContain('docs/CHANGELOG.md');
+  });
+
+  it('documents post-v1.0.0 catalog growth', () => {
+    expect(changelog).toMatch(/## \[Unreleased\]/);
+  });
+});


### PR DESCRIPTION
Closes #143

## Summary
Release records for v1.0.0 conflicted between `RELEASE.md` (2026-03-27, Phase 2 launch) and `docs/CHANGELOG.md` (2026-04-02, mixed post-tag work), and 54 of 60 catalog designs referenced thumbnails that did not exist — every one of those cards rendered a 404 image in production.

## Approach
- Make **`docs/CHANGELOG.md` the single authoritative release history**: corrected v1.0.0 to the actual tag date (2026-03-27), moved post-tag work into a new `[Unreleased]` section documenting catalog growth from 5 → 60 designs and modernization P1–P4 changes.
- Reduced `RELEASE.md` to a cross-linked pointer stub that no longer duplicates records.
- Added `scripts/generate-thumbnails.js`, which renders a branded 400x300 SVG per design from its own palette (`background`/`foreground`/`primary` HSL or hex tokens) and generated the 54 missing `{slug}-thumb.svg` files. The script is idempotent (`--force` regenerates all).
- Unsafe characters are neutralized before interpolation into SVG attributes; design names are XML-escaped.

## Decision Record
Selected the balanced option over (a) docs-only fallback-image mitigation and (c) a full custom-artwork/release pipeline: generating palette-derived thumbnails eliminates every 404 with real previews while staying reproducible via one committed script, and the changelog consolidation gives exactly one authoritative record per version without deleting history.

## Changes
| File | Change |
|------|--------|
| `docs/CHANGELOG.md` | Authoritative history: fixed v1.0.0 date/contents, added `[Unreleased]` section |
| `RELEASE.md` | Replaced duplicated record with cross-link to changelog |
| `scripts/generate-thumbnails.js` | New: idempotent thumbnail generator from design palettes |
| `public/previews/*-thumb.svg` (+54) | Generated missing thumbnails — 60/60 designs covered |
| `tests/thumbnails.test.js` | New regression guard |

## Test Results
- `npm test`: **28 suites, 275/275 passed** (65 new test cases)
- `npm run validate:designs`: all 60 designs valid
- `npm run lint` / `npm run typecheck`: clean

## Acceptance Criteria Verification
| Criterion | Status |
|-----------|--------|
| Exactly one authoritative release record per version, cross-linked; post-v1.0.0 entries present | ✅ CHANGELOG is single source (test asserts no duplicate version headers); RELEASE.md is a pointer stub; `[Unreleased]` covers 5 → 60 design growth |
| ≥60 `*-thumb.svg` files OR a test asserting every slug resolves to an existing thumbnail/fallback (zero 404 URLs) | ✅ Both: 60 thumbs on disk, plus tests asserting each design's `preview.thumbnail` exists and each slug has a thumb |
| `npm test` passes at baseline-green pass rate | ✅ 275/275 passed, coverage thresholds met |