### PR TITLE
feat(home): update GitHub stats on website in real time (#179)

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -47,6 +47,11 @@ const designsModule = jest.requireMock('@/data/designs') as {
 beforeEach(() => {
   designsModule.loadDesigns.mockResolvedValue([testCatalogEntry]);
   designsModule.loadDesignData.mockResolvedValue(null);
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => ({ stargazers_count: 126, forks_count: 11 }),
+  }) as unknown as typeof fetch;
 });
 
 describe('HomePage - Social Proof Section (#79)', () => {
@@ -88,6 +93,28 @@ describe('HomePage - Social Proof Section (#79)', () => {
     links.forEach(link => {
       expect(link.closest('a')).toHaveAttribute('href', 'https://github.com/luongnv89/sleek-ui');
     });
+  });
+});
+
+describe('HomePage - Live GitHub stats (#179)', () => {
+  it('displays live values fetched from the GitHub API at view time', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ stargazers_count: 250, forks_count: 30 }),
+    }) as unknown as typeof fetch;
+
+    render(<App />);
+    await waitFor(() => expect(screen.getByText('~250')).toBeInTheDocument());
+    expect(screen.getByText('~30')).toBeInTheDocument();
+  });
+
+  it('falls back to last-known values when the GitHub API is unavailable', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error('rate limited')) as unknown as typeof fetch;
+
+    render(<App />);
+    expect(screen.getByText('~126')).toBeInTheDocument();
+    expect(screen.getByText('~11')).toBeInTheDocument();
   });
 });
 

--- a/src/components/home/SocialProofSection.tsx
+++ b/src/components/home/SocialProofSection.tsx
@@ -1,20 +1,28 @@
 import { GithubIcon } from '@/components/ui/GithubIcon';
 import { useDesignCatalog } from '@/hooks/useDesignCatalog';
+import { useGithubStats } from '@/hooks/useGithubStats';
+
+// Last-known values shown while loading or when the GitHub API is
+// unavailable/rate-limited (#179)
+const FALLBACK_STATS = { stars: 126, forks: 11 };
 
 export function SocialProofSection() {
   // Design-system stat is derived from the catalog, not hardcoded (#141)
   const { designs, loading } = useDesignCatalog();
   const designCount = loading ? null : designs.length;
+  const { stats } = useGithubStats();
+  const stars = stats?.stars ?? FALLBACK_STATS.stars;
+  const forks = stats?.forks ?? FALLBACK_STATS.forks;
   return (
     <section className="border-t border-border/60 bg-background px-4 py-10 sm:py-12">
       <div className="mx-auto max-w-4xl">
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-6 text-center">
           <div className="rounded-xl border border-border/60 bg-muted/10 p-5">
-            <div className="text-2xl font-bold text-brand tabular-nums" title="Approximate, as of August 2026">~126</div>
+            <div className="text-2xl font-bold text-brand tabular-nums" title="Live from the GitHub API">~{stars}</div>
             <div className="text-xs uppercase tracking-wider text-muted-foreground mt-1">GitHub Stars</div>
           </div>
           <div className="rounded-xl border border-border/60 bg-muted/10 p-5">
-            <div className="text-2xl font-bold text-brand tabular-nums" title="Approximate, as of August 2026">~11</div>
+            <div className="text-2xl font-bold text-brand tabular-nums" title="Live from the GitHub API">~{forks}</div>
             <div className="text-xs uppercase tracking-wider text-muted-foreground mt-1">Forks</div>
           </div>
           <div className="rounded-xl border border-border/60 bg-muted/10 p-5">

--- a/src/hooks/__tests__/useGithubStats.test.tsx
+++ b/src/hooks/__tests__/useGithubStats.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen, act } from '@testing-library/react';
+import { useGithubStats } from '../useGithubStats';
+
+function apiResponse(stars: number, forks: number): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({ stargazers_count: stars, forks_count: forks }),
+  } as Response;
+}
+
+function mockFetch(impl: () => Promise<Response>) {
+  const fetchMock = jest.fn(impl);
+  global.fetch = fetchMock as unknown as typeof fetch;
+  return fetchMock;
+}
+
+// Drain pending promise chains (fetch -> json -> setState) inside act
+async function flushAsyncChain() {
+  await act(async () => {
+    for (let i = 0; i < 10; i++) {
+      await Promise.resolve();
+    }
+  });
+}
+
+// Capture the polling callback registered with setInterval so tests can
+// simulate the passage of time without relying on fake timers
+function capturePollCallback() {
+  let poll!: () => void;
+  jest
+    .spyOn(global, 'setInterval')
+    .mockImplementation((cb: () => void) => {
+      poll = cb;
+      return 0 as unknown as ReturnType<typeof setInterval>;
+    });
+  return () => poll();
+}
+
+function Harness() {
+  const { stats, loading } = useGithubStats();
+  return (
+    <div>
+      <span data-testid="stars">{stats ? `~${stats.stars}` : 'none'}</span>
+      <span data-testid="forks">{stats ? `~${stats.forks}` : 'none'}</span>
+      <span data-testid="loading">{loading ? 'loading' : 'done'}</span>
+    </div>
+  );
+}
+
+describe('useGithubStats (#179)', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('fetches live stars and forks on mount', async () => {
+    mockFetch(() => Promise.resolve(apiResponse(250, 30)));
+    render(<Harness />);
+    await flushAsyncChain();
+
+    expect(screen.getByTestId('loading')).toHaveTextContent('done');
+    expect(screen.getByTestId('stars')).toHaveTextContent('~250');
+    expect(screen.getByTestId('forks')).toHaveTextContent('~30');
+  });
+
+  it('keeps last-known values when the GitHub API fails (graceful degradation)', async () => {
+    const poll = capturePollCallback();
+    mockFetch(() => Promise.resolve(apiResponse(250, 30)));
+    render(<Harness />);
+    await flushAsyncChain();
+    expect(screen.getByTestId('stars')).toHaveTextContent('~250');
+
+    mockFetch(() => Promise.reject(new Error('rate limited')));
+    await act(async () => {
+      poll();
+    });
+    await flushAsyncChain();
+
+    expect(screen.getByTestId('stars')).toHaveTextContent('~250');
+    expect(screen.getByTestId('forks')).toHaveTextContent('~30');
+  });
+
+  it('treats non-OK responses (e.g. rate-limited 403) as a failure, not an update', async () => {
+    mockFetch(() =>
+      Promise.resolve({
+        ok: false,
+        status: 403,
+        json: async () => ({}),
+      } as Response)
+    );
+    render(<Harness />);
+    await flushAsyncChain();
+
+    expect(screen.getByTestId('loading')).toHaveTextContent('done');
+    expect(screen.getByTestId('stars')).toHaveTextContent('none');
+  });
+
+  it('polls for fresh values while the page stays open', async () => {
+    const poll = capturePollCallback();
+    const fetchMock = mockFetch(() => Promise.resolve(apiResponse(250, 30)));
+    render(<Harness />);
+    await flushAsyncChain();
+    expect(screen.getByTestId('stars')).toHaveTextContent('~250');
+
+    (fetchMock as jest.Mock).mockImplementation(() =>
+      Promise.resolve(apiResponse(300, 30))
+    );
+    await act(async () => {
+      poll();
+    });
+    await flushAsyncChain();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(screen.getByTestId('stars')).toHaveTextContent('~300');
+  });
+});

--- a/src/hooks/useGithubStats.ts
+++ b/src/hooks/useGithubStats.ts
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react';
+
+const REPO_API_URL = 'https://api.github.com/repos/luongnv89/sleek-ui';
+const POLL_INTERVAL_MS = 5 * 60 * 1000;
+
+export interface GithubStats {
+  stars: number;
+  forks: number;
+}
+
+export function useGithubStats(): { stats: GithubStats | null; loading: boolean } {
+  const [stats, setStats] = useState<GithubStats | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let alive = true;
+
+    const fetchStats = async () => {
+      try {
+        const res = await fetch(REPO_API_URL, {
+          headers: { Accept: 'application/vnd.github+json' },
+        });
+        if (!res.ok) throw new Error(`GitHub API responded with ${res.status}`);
+        const data = await res.json();
+        if (!alive) return;
+        if (typeof data.stargazers_count !== 'number' || typeof data.forks_count !== 'number') {
+          throw new Error('Unexpected GitHub API payload');
+        }
+        setStats({ stars: data.stargazers_count, forks: data.forks_count });
+      } catch {
+        // Keep last-known values on network failure or rate limiting (#179)
+      } finally {
+        if (alive) setLoading(false);
+      }
+    };
+
+    void fetchStats();
+    const intervalId = setInterval(() => void fetchStats(), POLL_INTERVAL_MS);
+
+    return () => {
+      alive = false;
+      clearInterval(intervalId);
+    };
+  }, []);
+
+  return { stats, loading };
+}


### PR DESCRIPTION
## Summary

GitHub stats (stars, forks) in the landing page social-proof section were static build-time snapshots. They are now fetched live from the GitHub API at view time and refreshed while the page stays open.

Closes #179

## Approach

Selected **Option 2 — polling hook with stale-value fallback** (per `.gitissue/analysis-179.json`):

- New `useGithubStats` hook fetches `api.github.com/repos/luongnv89/sleek-ui` on mount and polls every 5 minutes while the page is open.
- On network failure, non-OK responses (e.g. rate-limited 403), or unexpected payloads, last-known values are kept; before any successful fetch, static fallbacks (~126 / ~11) render, so the section never breaks or shifts layout.
- Unmount-safe (`alive` guard + interval cleanup); errors are caught silently — no new console errors.

Alternatives considered: serverless proxy/Actions-injected build values (rejected: infra cost for a P2 display nicety) and fetch-on-mount only (rejected: fails the "updates while page is open" criterion).

## Decision Record

| Field | Value |
|---|---|
| Issue | #179 |
| Type | feature |
| Complexity | medium |
| Selected option | Option 2 — polling hook with stale-value fallback |
| Risk rating | low |
| Profile | full |

## Changes

| File | Change |
|---|---|
| `src/hooks/useGithubStats.ts` | New hook: mount fetch + 5-min polling + stale-value fallback |
| `src/components/home/SocialProofSection.tsx` | Renders live stats with static fallbacks; title updated to reflect liveness |
| `src/hooks/__tests__/useGithubStats.test.tsx` | New unit tests: mount fetch, degradation, non-OK handling, polling |
| `src/App.test.tsx` | Integration tests: live values rendered; fallback shown when API unavailable |

## Test Results

- `npm test`: 29 suites, 281 tests passed (6 new)
- `npm run build`: green

## Acceptance Criteria Verification

| Criterion | Status |
|---|---|
| Stats reflect live values fetched at view time | ✅ Fetched from GitHub API on mount (covered by tests) |
| Stats update automatically without reload/redeploy | ✅ 5-minute in-page polling (covered by test) |
| Graceful degradation when API unavailable/rate-limited | ✅ Last-known/static fallbacks kept (covered by tests) |
| No new console errors or layout shifts | ✅ Errors caught; same `~N` format with `tabular-nums` |